### PR TITLE
Include our own address when fetching addresses within a group

### DIFF
--- a/aw.go
+++ b/aw.go
@@ -37,7 +37,7 @@ type (
 
 	// Peers
 	Peer             = peer.Peer
-	PeerOption       = peer.Options
+	PeerOptions      = peer.Options
 	PeerID           = protocol.PeerID
 	PeerIDs          = protocol.PeerIDs
 	GroupID          = protocol.GroupID
@@ -55,8 +55,8 @@ type (
 	Handshaker     = handshake.Handshaker
 
 	// Options
-	TcpConnPoolOption = tcp.ConnPoolOptions
-	TcpServerOption   = tcp.ServerOptions
+	TcpConnPoolOptions = tcp.ConnPoolOptions
+	TcpServerOptions   = tcp.ServerOptions
 )
 
 // Default values

--- a/aw.go
+++ b/aw.go
@@ -40,7 +40,7 @@ type (
 	PeerOption       = peer.Options
 	PeerID           = protocol.PeerID
 	PeerIDs          = protocol.PeerIDs
-	PeerGroupID      = protocol.PeerGroupID
+	GroupID          = protocol.GroupID
 	PeerAddress      = protocol.PeerAddress
 	PeerAddresses    = protocol.PeerAddresses
 	PeerAddressCodec = protocol.PeerAddressCodec
@@ -60,7 +60,7 @@ type (
 )
 
 // Default values
-var NilPeerGroupID = protocol.NilPeerGroupID
+var NilGroupID = protocol.NilGroupID
 
 // Constructors
 var (

--- a/aw.go
+++ b/aw.go
@@ -55,8 +55,8 @@ type (
 	Handshaker     = handshake.Handshaker
 
 	// Options
-	TcpConnPoolOptions = tcp.ConnPoolOptions
-	TcpServerOptions   = tcp.ServerOptions
+	TCPConnPoolOptions = tcp.ConnPoolOptions
+	TCPServerOptions   = tcp.ServerOptions
 )
 
 // Default values
@@ -67,8 +67,8 @@ var (
 	NewMessage   = protocol.NewMessage
 	NewPeer      = peer.New
 	NewDHT       = dht.New
-	NewTcpPeer   = peer.NewTCP
+	NewTCPPeer   = peer.NewTCP
 	NewConnPool  = tcp.NewConnPool
-	NewTcpClient = tcp.NewClient
-	NewTcpServer = tcp.NewServer
+	NewTCPClient = tcp.NewClient
+	NewTCPServer = tcp.NewServer
 )

--- a/broadcast/broadcast.go
+++ b/broadcast/broadcast.go
@@ -22,7 +22,7 @@ import (
 // the message to all known peers.
 type Broadcaster interface {
 	// Broadcast a message to all peers in the network.
-	Broadcast(ctx context.Context, groupID protocol.PeerGroupID, body protocol.MessageBody) error
+	Broadcast(ctx context.Context, groupID protocol.GroupID, body protocol.MessageBody) error
 
 	// AcceptBroadcast message from another peer in the network.
 	AcceptBroadcast(ctx context.Context, from protocol.PeerID, message protocol.Message) error
@@ -54,7 +54,7 @@ func NewBroadcaster(logger logrus.FieldLogger, numWorkers int, messages protocol
 
 // Broadcast a message to multiple remote servers in an attempt to saturate the
 // network.
-func (broadcaster *broadcaster) Broadcast(ctx context.Context, groupID protocol.PeerGroupID, body protocol.MessageBody) error {
+func (broadcaster *broadcaster) Broadcast(ctx context.Context, groupID protocol.GroupID, body protocol.MessageBody) error {
 	// Ignore message if it already been sent.
 	message := protocol.NewMessage(protocol.V1, protocol.Broadcast, groupID, body)
 	ok, err := broadcaster.messageHashAlreadySeen(message.Hash())
@@ -65,8 +65,8 @@ func (broadcaster *broadcaster) Broadcast(ctx context.Context, groupID protocol.
 		return nil
 	}
 
-	// Get all peer details of the Group ID.
-	addrs, err := broadcaster.dht.PeerGroupAddresses(groupID)
+	// Get all addresses in the group with the given ID.
+	addrs, err := broadcaster.dht.GroupAddresses(groupID)
 	if err != nil {
 		return err
 	}
@@ -176,7 +176,7 @@ type ErrBroadcasting struct {
 	error
 }
 
-func newErrBroadcasting(err error, groupID protocol.PeerGroupID) error {
+func newErrBroadcasting(err error, groupID protocol.GroupID) error {
 	return ErrBroadcasting{
 		error: fmt.Errorf("error broadcasting to group [%v] : %v", groupID, err),
 	}

--- a/broadcast/broadcast_test.go
+++ b/broadcast/broadcast_test.go
@@ -107,10 +107,10 @@ var _ = Describe("Broadcaster", func() {
 					dht := NewDHT(RandomAddress(), NewTable("dht"), nil)
 					broadcaster := NewBroadcaster(logrus.New(), 8, messages, events, dht)
 
-					groupID, addrs := RandomPeerGroupID(), RandomAddresses(rand.Intn(32))
+					groupID, addrs := RandomGroupID(), RandomAddresses(rand.Intn(32))
 					last := RandomAddress()
 					addrs = append(addrs, last)
-					Expect(dht.AddPeerGroup(groupID, FromAddressesToIDs(addrs))).NotTo(HaveOccurred())
+					Expect(dht.AddGroup(groupID, FromAddressesToIDs(addrs))).NotTo(HaveOccurred())
 					for i := 0; i < len(addrs)-1; i++ {
 						Expect(dht.AddPeerAddress(addrs[i])).NotTo(HaveOccurred())
 					}
@@ -145,11 +145,11 @@ var _ = Describe("Broadcaster", func() {
 				dht := NewDHT(RandomAddress(), NewTable("dht"), nil)
 				broadcaster := NewBroadcaster(logrus.New(), 8, messages, events, dht)
 
-				groupID, addrs := RandomPeerGroupID(), RandomAddresses(rand.Intn(32))
+				groupID, addrs := RandomGroupID(), RandomAddresses(rand.Intn(32))
 				for _, addr := range addrs {
 					Expect(dht.AddPeerAddress(addr)).NotTo(HaveOccurred())
 				}
-				Expect(dht.AddPeerGroup(groupID, FromAddressesToIDs(addrs))).NotTo(HaveOccurred())
+				Expect(dht.AddGroup(groupID, FromAddressesToIDs(addrs))).NotTo(HaveOccurred())
 
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
@@ -184,7 +184,7 @@ var _ = Describe("Broadcaster", func() {
 
 					ctx, cancel := context.WithCancel(context.Background())
 					cancel()
-					message := protocol.NewMessage(protocol.V1, protocol.Broadcast, RandomPeerGroupID(), messageBody)
+					message := protocol.NewMessage(protocol.V1, protocol.Broadcast, RandomGroupID(), messageBody)
 					Expect(broadcaster.AcceptBroadcast(ctx, RandomPeerID(), message)).To(HaveOccurred())
 
 					return true
@@ -204,7 +204,7 @@ var _ = Describe("Broadcaster", func() {
 
 					ctx, cancel := context.WithCancel(context.Background())
 					defer cancel()
-					message := protocol.NewMessage(protocol.V1, protocol.Broadcast, RandomPeerGroupID(), messageBody)
+					message := protocol.NewMessage(protocol.V1, protocol.Broadcast, RandomGroupID(), messageBody)
 					message.Version = InvalidMessageVersion()
 					Expect(broadcaster.AcceptBroadcast(ctx, RandomPeerID(), message)).To(HaveOccurred())
 
@@ -225,7 +225,7 @@ var _ = Describe("Broadcaster", func() {
 
 					ctx, cancel := context.WithCancel(context.Background())
 					defer cancel()
-					message := protocol.NewMessage(protocol.V1, protocol.Broadcast, RandomPeerGroupID(), messageBody)
+					message := protocol.NewMessage(protocol.V1, protocol.Broadcast, RandomGroupID(), messageBody)
 					message.Variant = InvalidMessageVariant(protocol.Broadcast)
 					Expect(broadcaster.AcceptBroadcast(ctx, RandomPeerID(), message)).To(HaveOccurred())
 
@@ -245,11 +245,11 @@ var _ = Describe("Broadcaster", func() {
 					broadcaster := NewBroadcaster(logrus.New(), 8, messages, events, dht)
 
 					// Intentionally not inserting the last peer address to the dht.
-					groupID, addrs := RandomPeerGroupID(), RandomAddresses(rand.Intn(32))
+					groupID, addrs := RandomGroupID(), RandomAddresses(rand.Intn(32))
 					for _, addr := range addrs {
 						Expect(dht.AddPeerAddress(addr)).NotTo(HaveOccurred())
 					}
-					Expect(dht.AddPeerGroup(groupID, FromAddressesToIDs(addrs))).NotTo(HaveOccurred())
+					Expect(dht.AddGroup(groupID, FromAddressesToIDs(addrs))).NotTo(HaveOccurred())
 
 					ctx, cancel := context.WithCancel(context.Background())
 					defer cancel()

--- a/cast/cast.go
+++ b/cast/cast.go
@@ -38,7 +38,7 @@ func (caster *caster) Cast(ctx context.Context, to protocol.PeerID, body protoco
 	}
 	message := protocol.MessageOnTheWire{
 		To:      toAddr,
-		Message: protocol.NewMessage(protocol.V1, protocol.Cast, protocol.NilPeerGroupID, body),
+		Message: protocol.NewMessage(protocol.V1, protocol.Cast, protocol.NilGroupID, body),
 	}
 
 	// Check if context is already expired

--- a/cast/cast_test.go
+++ b/cast/cast_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Caster", func() {
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
 
-				message := protocol.NewMessage(protocol.V1, protocol.Cast, protocol.NilPeerGroupID, messageBody)
+				message := protocol.NewMessage(protocol.V1, protocol.Cast, protocol.NilGroupID, messageBody)
 				Expect(caster.AcceptCast(ctx, RandomPeerID(), message)).NotTo(HaveOccurred())
 
 				var event protocol.EventMessageReceived
@@ -103,7 +103,7 @@ var _ = Describe("Caster", func() {
 					ctx, cancel := context.WithCancel(context.Background())
 					cancel()
 
-					message := protocol.NewMessage(protocol.V1, protocol.Cast, protocol.NilPeerGroupID, messageBody)
+					message := protocol.NewMessage(protocol.V1, protocol.Cast, protocol.NilGroupID, messageBody)
 					Expect(caster.AcceptCast(ctx, RandomPeerID(), message)).Should(HaveOccurred())
 
 					return true
@@ -124,7 +124,7 @@ var _ = Describe("Caster", func() {
 					ctx, cancel := context.WithCancel(context.Background())
 					defer cancel()
 
-					message := protocol.NewMessage(protocol.V1, protocol.Cast, protocol.NilPeerGroupID, messageBody)
+					message := protocol.NewMessage(protocol.V1, protocol.Cast, protocol.NilGroupID, messageBody)
 					message.Version = InvalidMessageVersion()
 					Expect(caster.AcceptCast(ctx, RandomPeerID(), message)).Should(HaveOccurred())
 
@@ -146,7 +146,7 @@ var _ = Describe("Caster", func() {
 					ctx, cancel := context.WithCancel(context.Background())
 					defer cancel()
 
-					message := protocol.NewMessage(protocol.V1, protocol.Cast, protocol.NilPeerGroupID, messageBody)
+					message := protocol.NewMessage(protocol.V1, protocol.Cast, protocol.NilGroupID, messageBody)
 					message.Variant = InvalidMessageVariant(protocol.Cast)
 
 					Expect(caster.AcceptCast(ctx, RandomPeerID(), message)).Should(HaveOccurred())

--- a/dht/dht.go
+++ b/dht/dht.go
@@ -27,7 +27,8 @@ type DHT interface {
 	// PeerAddresses returns all the PeerAddresses stored in the DHT.
 	PeerAddresses() (protocol.PeerAddresses, error)
 
-	// RandomPeerAddresses returns (at max) n random PeerAddresses in the given peer group.
+	// RandomPeerAddresses returns (at max) n random PeerAddresses in the given
+	// peer group.
 	RandomPeerAddresses(id protocol.GroupID, n int) (protocol.PeerAddresses, error)
 
 	// AddPeerAddress adds a PeerAddress into the DHT.
@@ -41,17 +42,17 @@ type DHT interface {
 	// It wouldn't return any error if the PeerAddress doesn't exist.
 	RemovePeerAddress(protocol.PeerID) error
 
-	// AddGroup creates a new Group in the dht with given name and PeerIDs.
+	// AddGroup creates a new group in the DHT with given ID and PeerIDs.
 	AddGroup(protocol.GroupID, protocol.PeerIDs) error
 
-	// GroupIDs returns the PeerIDs of the given GroupID
+	// GroupIDs returns the PeerIDs in the group with the given ID.
 	GroupIDs(protocol.GroupID) (protocol.PeerIDs, error)
 
-	// GroupAddresses returns the PeerAddresses of the given GroupID. It
-	// will not return Peers which we don't have the PeerAddresses.
+	// GroupAddresses returns the PeerAddresses in the group with the given ID.
+	// It will not return peers for which we do not have the PeerAddresses.
 	GroupAddresses(protocol.GroupID) (protocol.PeerAddresses, error)
 
-	// Remove a Group with given name from the DHT.
+	// Remove a group from the DHT with the given ID.
 	RemoveGroup(protocol.GroupID)
 }
 

--- a/dht/dht.go
+++ b/dht/dht.go
@@ -235,6 +235,10 @@ func (dht *dht) PeerGroupAddresses(groupID protocol.PeerGroupID) (protocol.PeerA
 	dht.inMemCacheMu.RLock()
 	defer dht.inMemCacheMu.RUnlock()
 	for _, id := range ids {
+		if id.Equal(dht.me.PeerID()) {
+			addrs = append(addrs, dht.me)
+			continue
+		}
 		addr, ok := dht.inMemCache[id.String()]
 		if !ok {
 			continue

--- a/dht/dht_test.go
+++ b/dht/dht_test.go
@@ -229,20 +229,24 @@ var _ = Describe("DHT", func() {
 	Context("when creating, querying and deleting Groups", func() {
 		It("should be able to adding new group and delete a existing group", func() {
 			test := func() bool {
-				dht := NewDHT(RandomAddress(), NewTable("dht"), nil)
+				self := RandomAddress()
+				dht := NewDHT(self, NewTable("dht"), nil)
 				groupID, peerAddrs := RandomGroupID(), RandomAddresses(rand.Intn(32))
 				for _, peerAddr := range peerAddrs {
 					Expect(dht.AddPeerAddress(peerAddr)).NotTo(HaveOccurred())
 				}
+				// Append ourself to the group afterwards as we may not be in
+				// the list of peer addresses.
+				peerAddrs = append(peerAddrs, self)
 				peerIDs := FromAddressesToIDs(peerAddrs)
 
-				// Before adding the peer group
+				// Ensure no error occurs prior to adding the group.
 				ids, err := dht.GroupIDs(groupID)
 				Expect(err).To(HaveOccurred())
 				_, err = dht.GroupAddresses(groupID)
 				Expect(err).To(HaveOccurred())
 
-				// Adding the peer group
+				// Add the group and verify lengths.
 				Expect(dht.AddGroup(groupID, peerIDs)).NotTo(HaveOccurred())
 				ids, err = dht.GroupIDs(groupID)
 				Expect(err).NotTo(HaveOccurred())
@@ -251,7 +255,7 @@ var _ = Describe("DHT", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(len(addrs)).Should(Equal(len(peerIDs)))
 
-				// After removing the peer group
+				// Remove the group and ensure no error occurs.
 				dht.RemoveGroup(groupID)
 				ids, err = dht.GroupIDs(groupID)
 				Expect(err).To(HaveOccurred())

--- a/multicast/multicast.go
+++ b/multicast/multicast.go
@@ -11,7 +11,7 @@ import (
 )
 
 type Multicaster interface {
-	Multicast(ctx context.Context, groupID protocol.PeerGroupID, body protocol.MessageBody) error
+	Multicast(ctx context.Context, groupID protocol.GroupID, body protocol.MessageBody) error
 	AcceptMulticast(ctx context.Context, from protocol.PeerID, message protocol.Message) error
 }
 
@@ -33,8 +33,8 @@ func NewMulticaster(logger logrus.FieldLogger, numWorkers int, messages protocol
 	}
 }
 
-func (multicaster *multicaster) Multicast(ctx context.Context, groupID protocol.PeerGroupID, body protocol.MessageBody) error {
-	addrs, err := multicaster.dht.PeerGroupAddresses(groupID)
+func (multicaster *multicaster) Multicast(ctx context.Context, groupID protocol.GroupID, body protocol.MessageBody) error {
+	addrs, err := multicaster.dht.GroupAddresses(groupID)
 	if err != nil {
 		return err
 	}
@@ -97,14 +97,14 @@ func (multicaster *multicaster) AcceptMulticast(ctx context.Context, from protoc
 }
 
 type ErrMulticasting struct {
-	protocol.PeerGroupID
+	protocol.GroupID
 	error
 }
 
-func newErrMulticasting(err error, groupID protocol.PeerGroupID) error {
+func newErrMulticasting(err error, groupID protocol.GroupID) error {
 	return ErrMulticasting{
-		PeerGroupID: groupID,
-		error:       fmt.Errorf("error multicasting to group %v: %v", groupID, err),
+		GroupID: groupID,
+		error:   fmt.Errorf("error multicasting to group %v: %v", groupID, err),
 	}
 }
 

--- a/multicast/multicast_test.go
+++ b/multicast/multicast_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Multicaster", func() {
 
 					ctx, cancel := context.WithCancel(context.Background())
 					defer cancel()
-					Expect(multicaster.Multicast(ctx, RandomPeerGroupID(), messageBody)).Should(HaveOccurred())
+					Expect(multicaster.Multicast(ctx, RandomGroupID(), messageBody)).Should(HaveOccurred())
 					return true
 				}
 
@@ -93,8 +93,8 @@ var _ = Describe("Multicaster", func() {
 
 					ctx, cancel := context.WithCancel(context.Background())
 					defer cancel()
-					groupID := RandomPeerGroupID()
-					Expect(dht.AddPeerGroup(groupID, RandomPeerIDs())).NotTo(HaveOccurred())
+					groupID := RandomGroupID()
+					Expect(dht.AddGroup(groupID, RandomPeerIDs())).NotTo(HaveOccurred())
 					Expect(multicaster.Multicast(ctx, groupID, messageBody)).ShouldNot(HaveOccurred())
 					return true
 				}
@@ -114,7 +114,7 @@ var _ = Describe("Multicaster", func() {
 
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
-				message := protocol.NewMessage(protocol.V1, protocol.Multicast, RandomPeerGroupID(), messageBody)
+				message := protocol.NewMessage(protocol.V1, protocol.Multicast, RandomGroupID(), messageBody)
 				Expect(multicaster.AcceptMulticast(ctx, RandomPeerID(), message)).ToNot(HaveOccurred())
 
 				var event protocol.EventMessageReceived
@@ -135,7 +135,7 @@ var _ = Describe("Multicaster", func() {
 				ctx, cancel := context.WithCancel(context.Background())
 				cancel()
 
-				message := protocol.NewMessage(protocol.V1, protocol.Multicast, RandomPeerGroupID(), protocol.MessageBody{})
+				message := protocol.NewMessage(protocol.V1, protocol.Multicast, RandomGroupID(), protocol.MessageBody{})
 				Expect(multicaster.AcceptMulticast(ctx, RandomPeerID(), message)).To(HaveOccurred())
 			})
 		})
@@ -150,7 +150,7 @@ var _ = Describe("Multicaster", func() {
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
 
-				message := protocol.NewMessage(protocol.V1, protocol.Multicast, RandomPeerGroupID(), protocol.MessageBody{})
+				message := protocol.NewMessage(protocol.V1, protocol.Multicast, RandomGroupID(), protocol.MessageBody{})
 				message.Version = InvalidMessageVersion()
 				Expect(multicaster.AcceptMulticast(ctx, RandomPeerID(), message)).To(HaveOccurred())
 			})
@@ -166,7 +166,7 @@ var _ = Describe("Multicaster", func() {
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
 
-				message := protocol.NewMessage(protocol.V1, protocol.Multicast, RandomPeerGroupID(), protocol.MessageBody{})
+				message := protocol.NewMessage(protocol.V1, protocol.Multicast, RandomGroupID(), protocol.MessageBody{})
 				message.Variant = InvalidMessageVariant(protocol.Multicast)
 				Expect(multicaster.AcceptMulticast(ctx, RandomPeerID(), message)).To(HaveOccurred())
 			})

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -24,9 +24,9 @@ type Peer interface {
 
 	Cast(context.Context, protocol.PeerID, protocol.MessageBody) error
 
-	Multicast(context.Context, protocol.PeerGroupID, protocol.MessageBody) error
+	Multicast(context.Context, protocol.GroupID, protocol.MessageBody) error
 
-	Broadcast(context.Context, protocol.PeerGroupID, protocol.MessageBody) error
+	Broadcast(context.Context, protocol.GroupID, protocol.MessageBody) error
 }
 
 type peer struct {
@@ -139,7 +139,7 @@ func (peer *peer) PeerAddresses() (protocol.PeerAddresses, error) {
 	return peer.dht.PeerAddresses()
 }
 
-func (peer *peer) RandomPeerAddresses(id protocol.PeerGroupID, n int) (protocol.PeerAddresses, error) {
+func (peer *peer) RandomPeerAddresses(id protocol.GroupID, n int) (protocol.PeerAddresses, error) {
 	return peer.dht.RandomPeerAddresses(id, n)
 }
 
@@ -155,31 +155,31 @@ func (peer *peer) RemovePeerAddress(id protocol.PeerID) error {
 	return peer.dht.RemovePeerAddress(id)
 }
 
-func (peer *peer) AddPeerGroup(groupID protocol.PeerGroupID, ids protocol.PeerIDs) error {
-	return peer.dht.AddPeerGroup(groupID, ids)
+func (peer *peer) AddGroup(groupID protocol.GroupID, ids protocol.PeerIDs) error {
+	return peer.dht.AddGroup(groupID, ids)
 }
 
-func (peer *peer) PeerGroupIDs(groupID protocol.PeerGroupID) (protocol.PeerIDs, error) {
-	return peer.PeerGroupIDs(groupID)
+func (peer *peer) GroupIDs(groupID protocol.GroupID) (protocol.PeerIDs, error) {
+	return peer.GroupIDs(groupID)
 }
 
-func (peer *peer) PeerGroupAddresses(groupID protocol.PeerGroupID) (protocol.PeerAddresses, error) {
-	return peer.PeerGroupAddresses(groupID)
+func (peer *peer) GroupAddresses(groupID protocol.GroupID) (protocol.PeerAddresses, error) {
+	return peer.GroupAddresses(groupID)
 }
 
-func (peer *peer) RemovePeerGroup(groupID protocol.PeerGroupID) {
-	peer.dht.RemovePeerGroup(groupID)
+func (peer *peer) RemoveGroup(groupID protocol.GroupID) {
+	peer.dht.RemoveGroup(groupID)
 }
 
 func (peer *peer) Cast(ctx context.Context, to protocol.PeerID, data protocol.MessageBody) error {
 	return peer.caster.Cast(ctx, to, data)
 }
 
-func (peer *peer) Multicast(ctx context.Context, groupID protocol.PeerGroupID, data protocol.MessageBody) error {
+func (peer *peer) Multicast(ctx context.Context, groupID protocol.GroupID, data protocol.MessageBody) error {
 	return peer.multicaster.Multicast(ctx, groupID, data)
 }
 
-func (peer *peer) Broadcast(ctx context.Context, groupID protocol.PeerGroupID, data protocol.MessageBody) error {
+func (peer *peer) Broadcast(ctx context.Context, groupID protocol.GroupID, data protocol.MessageBody) error {
 	return peer.broadcaster.Broadcast(ctx, groupID, data)
 }
 

--- a/peer/peer_test.go
+++ b/peer/peer_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Peer", func() {
 
 		sender := rand.Intn(len(peers))
 		messageBody := RandomMessageBody()
-		Expect(peers[sender].Multicast(multicastCtx, protocol.NilPeerGroupID, messageBody)).NotTo(HaveOccurred())
+		Expect(peers[sender].Multicast(multicastCtx, protocol.NilGroupID, messageBody)).NotTo(HaveOccurred())
 
 		for i, event := range events {
 			if i == sender {
@@ -58,7 +58,7 @@ var _ = Describe("Peer", func() {
 		defer broadcastCancel()
 
 		sender := rand.Intn(len(peers))
-		Expect(peers[sender].Broadcast(broadcastCtx, protocol.NilPeerGroupID, messageBody)).NotTo(HaveOccurred())
+		Expect(peers[sender].Broadcast(broadcastCtx, protocol.NilGroupID, messageBody)).NotTo(HaveOccurred())
 
 		for i, event := range events {
 			if i == sender {

--- a/pingpong/pingpong.go
+++ b/pingpong/pingpong.go
@@ -53,7 +53,7 @@ func (pp *pingPonger) Ping(ctx context.Context, to protocol.PeerID) error {
 	}
 	messageWire := protocol.MessageOnTheWire{
 		To:      peerAddr,
-		Message: protocol.NewMessage(protocol.V1, protocol.Ping, protocol.NilPeerGroupID, me),
+		Message: protocol.NewMessage(protocol.V1, protocol.Ping, protocol.NilGroupID, me),
 	}
 
 	select {
@@ -123,7 +123,7 @@ func (pp *pingPonger) pong(ctx context.Context, to protocol.PeerAddress) error {
 	}
 	messageWire := protocol.MessageOnTheWire{
 		To:      to,
-		Message: protocol.NewMessage(protocol.V1, protocol.Pong, protocol.NilPeerGroupID, me),
+		Message: protocol.NewMessage(protocol.V1, protocol.Pong, protocol.NilGroupID, me),
 	}
 	select {
 	case <-ctx.Done():
@@ -134,7 +134,7 @@ func (pp *pingPonger) pong(ctx context.Context, to protocol.PeerAddress) error {
 }
 
 func (pp *pingPonger) propagatePing(ctx context.Context, sender protocol.PeerID, body protocol.MessageBody) error {
-	peerAddrs, err := pp.dht.RandomPeerAddresses(protocol.NilPeerGroupID, pp.options.Alpha)
+	peerAddrs, err := pp.dht.RandomPeerAddresses(protocol.NilGroupID, pp.options.Alpha)
 	if err != nil {
 		return err
 	}
@@ -145,7 +145,7 @@ func (pp *pingPonger) propagatePing(ctx context.Context, sender protocol.PeerID,
 		}
 		messageWire := protocol.MessageOnTheWire{
 			To:      addr,
-			Message: protocol.NewMessage(protocol.V1, protocol.Ping, protocol.NilPeerGroupID, body),
+			Message: protocol.NewMessage(protocol.V1, protocol.Ping, protocol.NilGroupID, body),
 		}
 		select {
 		case <-ctx.Done():

--- a/pingpong/pingpong_test.go
+++ b/pingpong/pingpong_test.go
@@ -112,7 +112,7 @@ var _ = Describe("Pingpong", func() {
 					data, err := codec.Encode(sender)
 					Expect(err).NotTo(HaveOccurred())
 
-					ping := protocol.NewMessage(protocol.V1, protocol.Ping, protocol.NilPeerGroupID, data)
+					ping := protocol.NewMessage(protocol.V1, protocol.Ping, protocol.NilGroupID, data)
 					Expect(pingpong.AcceptPing(ctx, ping)).NotTo(HaveOccurred())
 					Eventually(events).ShouldNot(Receive())
 					Eventually(messages).ShouldNot(Receive())
@@ -145,7 +145,7 @@ var _ = Describe("Pingpong", func() {
 					data, err := codec.Encode(sender)
 					Expect(err).NotTo(HaveOccurred())
 
-					ping := protocol.NewMessage(protocol.V1, protocol.Ping, protocol.NilPeerGroupID, data)
+					ping := protocol.NewMessage(protocol.V1, protocol.Ping, protocol.NilGroupID, data)
 					Expect(pingpong.AcceptPing(ctx, ping)).NotTo(HaveOccurred())
 
 					// Expect a pong message
@@ -205,11 +205,11 @@ var _ = Describe("Pingpong", func() {
 					data, err := codec.Encode(sender)
 					Expect(err).NotTo(HaveOccurred())
 
-					ping := protocol.NewMessage(protocol.V1, protocol.Ping, protocol.NilPeerGroupID, data)
+					ping := protocol.NewMessage(protocol.V1, protocol.Ping, protocol.NilGroupID, data)
 					ping.Variant = InvalidMessageVariant(protocol.Ping)
 					Expect(pingpong.AcceptPing(ctx, ping)).To(HaveOccurred())
 
-					ping = protocol.NewMessage(protocol.V1, protocol.Ping, protocol.NilPeerGroupID, data)
+					ping = protocol.NewMessage(protocol.V1, protocol.Ping, protocol.NilGroupID, data)
 					ping.Version = InvalidMessageVersion()
 					Expect(pingpong.AcceptPing(ctx, ping)).To(HaveOccurred())
 					return true
@@ -234,7 +234,7 @@ var _ = Describe("Pingpong", func() {
 					data, err := codec.Encode(me)
 					Expect(err).NotTo(HaveOccurred())
 
-					ping := protocol.NewMessage(protocol.V1, protocol.Ping, protocol.NilPeerGroupID, data)
+					ping := protocol.NewMessage(protocol.V1, protocol.Ping, protocol.NilGroupID, data)
 					Expect(pingpong.AcceptPing(ctx, ping)).NotTo(HaveOccurred())
 					return true
 				}
@@ -262,7 +262,7 @@ var _ = Describe("Pingpong", func() {
 					data, err := codec.Encode(sender)
 					Expect(err).NotTo(HaveOccurred())
 
-					pong := protocol.NewMessage(protocol.V1, protocol.Pong, protocol.NilPeerGroupID, data)
+					pong := protocol.NewMessage(protocol.V1, protocol.Pong, protocol.NilGroupID, data)
 					Expect(pingpong.AcceptPong(ctx, pong)).NotTo(HaveOccurred())
 					Eventually(events).ShouldNot(Receive())
 					return true
@@ -288,7 +288,7 @@ var _ = Describe("Pingpong", func() {
 					data, err := codec.Encode(sender)
 					Expect(err).NotTo(HaveOccurred())
 
-					pong := protocol.NewMessage(protocol.V1, protocol.Pong, protocol.NilPeerGroupID, data)
+					pong := protocol.NewMessage(protocol.V1, protocol.Pong, protocol.NilGroupID, data)
 					Expect(pingpong.AcceptPong(ctx, pong)).NotTo(HaveOccurred())
 
 					// Should receive EventPeerChanged event
@@ -323,11 +323,11 @@ var _ = Describe("Pingpong", func() {
 					data, err := codec.Encode(sender)
 					Expect(err).NotTo(HaveOccurred())
 
-					pong := protocol.NewMessage(protocol.V1, protocol.Pong, protocol.NilPeerGroupID, data)
+					pong := protocol.NewMessage(protocol.V1, protocol.Pong, protocol.NilGroupID, data)
 					pong.Variant = InvalidMessageVariant(protocol.Pong)
 					Expect(pingpong.AcceptPong(ctx, pong)).To(HaveOccurred())
 
-					pong = protocol.NewMessage(protocol.V1, protocol.Pong, protocol.NilPeerGroupID, data)
+					pong = protocol.NewMessage(protocol.V1, protocol.Pong, protocol.NilGroupID, data)
 					pong.Version = InvalidMessageVersion()
 					Expect(pingpong.AcceptPong(ctx, pong)).To(HaveOccurred())
 					return true

--- a/protocol/addr.go
+++ b/protocol/addr.go
@@ -40,23 +40,23 @@ type PeerIDCodec interface {
 	Decode([]byte) (PeerID, error)
 }
 
-// PeerGroup uniquely identifies a group of PeerIDs.
-type PeerGroupID [32]byte
+// GroupID uniquely identifies a group of PeerIDs.
+type GroupID [32]byte
 
-// NilPeerGroupID is a reserved GroupID and usually represents all known PeerIDs.
-var NilPeerGroupID = PeerGroupID{}
+// NilGroupID is a reserved GroupID and usually represents all known PeerIDs.
+var NilGroupID = GroupID{}
 
 // Equal compares two groupIDs and return if they are same.
-func (id PeerGroupID) Equal(another PeerGroupID) bool {
+func (id GroupID) Equal(another GroupID) bool {
 	return bytes.Equal(id[:], another[:])
 }
 
-// ValidatePeerGroupID checks if the PeerGroupID is valid under the given message
+// ValidateGroupID checks if the GroupID is valid under the given message
 // variant
-func ValidatePeerGroupID(groupID PeerGroupID, variant MessageVariant) error {
+func ValidateGroupID(groupID GroupID, variant MessageVariant) error {
 	if variant != Broadcast && variant != Multicast {
-		if groupID != NilPeerGroupID {
-			return ErrInvalidPeerGroupID
+		if groupID != NilGroupID {
+			return ErrInvalidGroupID
 		}
 	}
 	return nil

--- a/protocol/addr_test.go
+++ b/protocol/addr_test.go
@@ -10,27 +10,27 @@ import (
 )
 
 var _ = Describe("PeerAddress", func() {
-	Context("PeerGroupID", func() {
+	Context("GroupID", func() {
 		Context("when validating message GroupID", func() {
 			It("should be nil for Ping, Pong and Cast message", func() {
-				Expect(ValidatePeerGroupID(NilPeerGroupID, Ping)).To(BeNil())
-				Expect(ValidatePeerGroupID(NilPeerGroupID, Pong)).To(BeNil())
-				Expect(ValidatePeerGroupID(NilPeerGroupID, Cast)).To(BeNil())
-				Expect(ValidatePeerGroupID(NilPeerGroupID, Multicast)).To(BeNil())
-				Expect(ValidatePeerGroupID(NilPeerGroupID, Broadcast)).To(BeNil())
+				Expect(ValidateGroupID(NilGroupID, Ping)).To(BeNil())
+				Expect(ValidateGroupID(NilGroupID, Pong)).To(BeNil())
+				Expect(ValidateGroupID(NilGroupID, Cast)).To(BeNil())
+				Expect(ValidateGroupID(NilGroupID, Multicast)).To(BeNil())
+				Expect(ValidateGroupID(NilGroupID, Broadcast)).To(BeNil())
 
-				Expect(ValidatePeerGroupID(RandomPeerGroupID(), Ping)).NotTo(BeNil())
-				Expect(ValidatePeerGroupID(RandomPeerGroupID(), Pong)).NotTo(BeNil())
-				Expect(ValidatePeerGroupID(RandomPeerGroupID(), Cast)).NotTo(BeNil())
-				Expect(ValidatePeerGroupID(RandomPeerGroupID(), Multicast)).To(BeNil())
-				Expect(ValidatePeerGroupID(RandomPeerGroupID(), Broadcast)).To(BeNil())
+				Expect(ValidateGroupID(RandomGroupID(), Ping)).NotTo(BeNil())
+				Expect(ValidateGroupID(RandomGroupID(), Pong)).NotTo(BeNil())
+				Expect(ValidateGroupID(RandomGroupID(), Cast)).NotTo(BeNil())
+				Expect(ValidateGroupID(RandomGroupID(), Multicast)).To(BeNil())
+				Expect(ValidateGroupID(RandomGroupID(), Broadcast)).To(BeNil())
 			})
 		})
 
 		Context("when comparing groupID", func() {
 			It("should tell whether two groupID are the same", func() {
 				test := func() bool {
-					id := RandomPeerGroupID()
+					id := RandomGroupID()
 					return id.Equal(id)
 				}
 

--- a/protocol/error.go
+++ b/protocol/error.go
@@ -6,7 +6,7 @@ import (
 )
 
 var (
-	ErrInvalidPeerGroupID = errors.New("invalid peer group id")
+	ErrInvalidGroupID = errors.New("invalid group id")
 
 	ErrInvalidMessageLength = errors.New("invalid message length")
 )

--- a/protocol/message.go
+++ b/protocol/message.go
@@ -96,7 +96,7 @@ func (variant MessageVariant) String() string {
 }
 
 // Returns the message length (ex-messageBody) which equals to
-// len(MessageLength) + len(MessageVersion) + len(MessageVariant) + len(PeerGroupID)
+// len(MessageLength) + len(MessageVersion) + len(MessageVariant) + len(GroupID)
 func (variant MessageVariant) NonBodyLength() int {
 	switch variant {
 	case Ping, Pong, Cast:
@@ -131,19 +131,19 @@ type Message struct {
 	Length  MessageLength
 	Version MessageVersion
 	Variant MessageVariant
-	GroupID PeerGroupID
+	GroupID GroupID
 	Body    MessageBody
 }
 
 // NewMessage returns a new message with given version, variant and body.
-func NewMessage(version MessageVersion, variant MessageVariant, groupID PeerGroupID, body MessageBody) Message {
+func NewMessage(version MessageVersion, variant MessageVariant, groupID GroupID, body MessageBody) Message {
 	if err := ValidateMessageVersion(version); err != nil {
 		panic(err)
 	}
 	if err := ValidateMessageVariant(variant); err != nil {
 		panic(err)
 	}
-	if err := ValidatePeerGroupID(groupID, variant); err != nil {
+	if err := ValidateGroupID(groupID, variant); err != nil {
 		panic(err)
 	}
 	length := MessageLength(variant.NonBodyLength() + len(body))

--- a/protocol/message_test.go
+++ b/protocol/message_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Protocol", func() {
 			test := func() bool {
 				variant := RandomMessageVariant()
 				body := RandomMessageBody()
-				Expect(NewMessage(V1, variant, NilPeerGroupID, body)).ToNot(BeNil())
+				Expect(NewMessage(V1, variant, NilGroupID, body)).ToNot(BeNil())
 
 				return true
 			}
@@ -71,19 +71,19 @@ var _ = Describe("Protocol", func() {
 	Context("when creating invalid messages", func() {
 		It("should panic for invalid versions", func() {
 			messageBody := RandomMessageBody()
-			Expect(func() { NewMessage(InvalidMessageVersion(), Cast, NilPeerGroupID, messageBody) }).To(Panic())
+			Expect(func() { NewMessage(InvalidMessageVersion(), Cast, NilGroupID, messageBody) }).To(Panic())
 		})
 
 		It("should panic for invalid variants", func() {
 			messageBody := RandomMessageBody()
-			Expect(func() { NewMessage(V1, InvalidMessageVariant(), NilPeerGroupID, messageBody) }).To(Panic())
+			Expect(func() { NewMessage(V1, InvalidMessageVariant(), NilGroupID, messageBody) }).To(Panic())
 		})
 
 		It("should panic for invalid groupID", func() {
 			messageBody := RandomMessageBody()
-			Expect(func() { NewMessage(V1, Ping, RandomPeerGroupID(), messageBody) }).To(Panic())
-			Expect(func() { NewMessage(V1, Pong, RandomPeerGroupID(), messageBody) }).To(Panic())
-			Expect(func() { NewMessage(V1, Ping, RandomPeerGroupID(), messageBody) }).To(Panic())
+			Expect(func() { NewMessage(V1, Ping, RandomGroupID(), messageBody) }).To(Panic())
+			Expect(func() { NewMessage(V1, Pong, RandomGroupID(), messageBody) }).To(Panic())
+			Expect(func() { NewMessage(V1, Ping, RandomGroupID(), messageBody) }).To(Panic())
 		})
 	})
 

--- a/tcp/tcp.go
+++ b/tcp/tcp.go
@@ -44,7 +44,7 @@ func (client *Client) handleMessageOnTheWire(message protocol.MessageOnTheWire) 
 			return
 		}
 		client.logger.Debugf("error send %v message to %v: %v", message.Message.Variant, message.To.NetworkAddress(), err)
-		time.Sleep(5 * time.Second)
+		time.Sleep(time.Second)
 	}
 }
 

--- a/tcp/tcp_test.go
+++ b/tcp/tcp_test.go
@@ -108,18 +108,16 @@ var _ = Describe("TCP client and server", func() {
 			serverAddr := NewSimpleTCPPeerAddress(RandomPeerID().String(), "", "8080")
 			options := ServerOptions{
 				Host:      serverAddr.NetworkAddress().String(),
-				RateLimit: 2 * time.Second,
+				RateLimit: 500 * time.Millisecond,
 			}
 			messageReceiver := NewTCPServer(ctx, options, clientSignVerifier)
 
 			// Try to connect and send a message to server
 			_ = sendRandomMessage(messageSender, serverAddr)
-			Eventually(messageReceiver, 3*time.Second).Should(Receive())
+			Eventually(messageReceiver, 600*time.Millisecond).Should(Receive())
 
 			// Cancel the ctx which close the connection
-			time.Sleep(100 * time.Millisecond)
 			clientCancel()
-			time.Sleep(100 * time.Millisecond)
 
 			// Create a new client and send a message and expect it to be rejected.
 			messageSender = NewTCPClient(ctx, ConnPoolOptions{}, clientSignVerifier)
@@ -127,7 +125,7 @@ var _ = Describe("TCP client and server", func() {
 			Eventually(messageReceiver).ShouldNot(Receive())
 
 			// Wait for the rate limit expire
-			time.Sleep(3 * time.Second)
+			time.Sleep(600 * time.Millisecond)
 
 			// Expect the connection to be accepted by the server
 			message := sendRandomMessage(messageSender, serverAddr)

--- a/testutil/addr.go
+++ b/testutil/addr.go
@@ -62,9 +62,9 @@ func RandomPeerID() protocol.PeerID {
 	return SimplePeerID(RandomString())
 }
 
-func RandomPeerGroupID() protocol.PeerGroupID {
-	id := protocol.PeerGroupID{}
-	for id.Equal(protocol.NilPeerGroupID) {
+func RandomGroupID() protocol.GroupID {
+	id := protocol.GroupID{}
+	for id.Equal(protocol.NilGroupID) {
 		_, err := rand.Read(id[:])
 		if err != nil {
 			panic(fmt.Sprintf("cannot create random id, err = %v", err))

--- a/testutil/dht.go
+++ b/testutil/dht.go
@@ -23,8 +23,8 @@ func NewTable(name string) kv.Table {
 	return kv.NewTable(db, name)
 }
 
-func NewGroup(dht dht.DHT) (protocol.PeerGroupID, protocol.PeerAddresses, error) {
-	groupID := RandomPeerGroupID()
+func NewGroup(dht dht.DHT) (protocol.GroupID, protocol.PeerAddresses, error) {
+	groupID := RandomGroupID()
 	addrs := RandomAddresses(rand.Intn(32))
 	ids := make([]protocol.PeerID, len(addrs))
 	for i := range addrs {
@@ -33,6 +33,6 @@ func NewGroup(dht dht.DHT) (protocol.PeerGroupID, protocol.PeerAddresses, error)
 			return groupID, nil, err
 		}
 	}
-	err := dht.AddPeerGroup(groupID, ids)
+	err := dht.AddGroup(groupID, ids)
 	return groupID, addrs, err
 }

--- a/testutil/message.go
+++ b/testutil/message.go
@@ -62,10 +62,10 @@ func RandomMessageVariant() protocol.MessageVariant {
 
 func RandomMessage(version protocol.MessageVersion, variant protocol.MessageVariant) protocol.Message {
 	body := RandomMessageBody()
-	groupID := protocol.NilPeerGroupID
+	groupID := protocol.NilGroupID
 	length := 8
 	if variant == protocol.Multicast || variant == protocol.Broadcast {
-		groupID = RandomPeerGroupID()
+		groupID = RandomGroupID()
 		length = 40
 	}
 	return protocol.Message{


### PR DESCRIPTION
Currently, when fetching addresses within a group, the `PeerGroupAddresses` function uses the `dht.inMemCache` to retrieve `PeerAddresses` using a list of IDs. This map does not necessarily contain our own address and may only consist of peer addresses. This PR updates this function to add our own address if our ID is in the given list. Additionally, there are some nomenclature updates such as replacing the term `PeerGroup` with `Group` for clarity.