### PR TITLE
Fix deadlock when closing connections

### DIFF
--- a/tcp/conn.go
+++ b/tcp/conn.go
@@ -151,9 +151,6 @@ func (pool *connPool) closeConn(to string) {
 }
 
 func (pool *connPool) closeConnImmediately(to string) {
-	pool.mu.Lock()
-	defer pool.mu.Unlock()
-
 	if err := pool.conns[to].conn.Close(); err != nil {
 		pool.logger.Errorf("error closing connection to %v: %v", to, err)
 	}


### PR DESCRIPTION
This PR removes a redundant mutex lock from the `closeConnImmediately` function as this function is only called after the lock has been obtained.