### PR TITLE
Check if connection exists prior to closing

### DIFF
--- a/broadcast/broadcast_test.go
+++ b/broadcast/broadcast_test.go
@@ -107,13 +107,12 @@ var _ = Describe("Broadcaster", func() {
 					dht := NewDHT(RandomAddress(), NewTable("dht"), nil)
 					broadcaster := NewBroadcaster(logrus.New(), 8, messages, events, dht)
 
-					groupID, addrs := RandomGroupID(), RandomAddresses(rand.Intn(32))
-					last := RandomAddress()
-					addrs = append(addrs, last)
-					Expect(dht.AddGroup(groupID, FromAddressesToIDs(addrs))).NotTo(HaveOccurred())
-					for i := 0; i < len(addrs)-1; i++ {
-						Expect(dht.AddPeerAddress(addrs[i])).NotTo(HaveOccurred())
+					groupID, addrs, err := NewGroup(dht)
+					Expect(err).NotTo(HaveOccurred())
+					if addrs[0].PeerID().Equal(dht.Me().PeerID()) {
+						return true
 					}
+					Expect(dht.RemovePeerAddress(addrs[0].PeerID())).NotTo(HaveOccurred())
 
 					ctx, cancel := context.WithCancel(context.Background())
 					defer cancel()

--- a/tcp/conn.go
+++ b/tcp/conn.go
@@ -144,14 +144,22 @@ func (pool *connPool) closeConn(to string) {
 	pool.mu.Lock()
 	defer pool.mu.Unlock()
 
-	if err := pool.conns[to].conn.Close(); err != nil {
+	c, ok := pool.conns[to]
+	if !ok {
+		return
+	}
+	if err := c.conn.Close(); err != nil {
 		pool.logger.Errorf("error closing connection to %v: %v", to, err)
 	}
 	delete(pool.conns, to)
 }
 
 func (pool *connPool) closeConnImmediately(to string) {
-	if err := pool.conns[to].conn.Close(); err != nil {
+	c, ok := pool.conns[to]
+	if !ok {
+		return
+	}
+	if err := c.conn.Close(); err != nil {
 		pool.logger.Errorf("error closing connection to %v: %v", to, err)
 	}
 	delete(pool.conns, to)

--- a/testutil/dht.go
+++ b/testutil/dht.go
@@ -25,7 +25,7 @@ func NewTable(name string) kv.Table {
 
 func NewGroup(dht dht.DHT) (protocol.GroupID, protocol.PeerAddresses, error) {
 	groupID := RandomGroupID()
-	addrs := RandomAddresses(rand.Intn(32))
+	addrs := RandomAddresses(rand.Intn(32) + 1)
 
 	// Replace with dht address if the addresses array contains the dht address.
 	if ContainAddress(addrs, dht.Me()) {


### PR DESCRIPTION
This PR fixes an issue where the `closeConn` function causes a nil pointer dereference panic if the `closeConnImmediately` function has already removed the connection.