### PR TITLE
Return our own address when querying an ID

### DIFF
--- a/dht/dht.go
+++ b/dht/dht.go
@@ -154,6 +154,9 @@ func (dht *dht) PeerAddress(id protocol.PeerID) (protocol.PeerAddress, error) {
 	dht.inMemCacheMu.RLock()
 	defer dht.inMemCacheMu.RUnlock()
 
+	if id.Equal(dht.me.PeerID()){
+		return dht.me, nil
+	}
 	peerAddr, ok := dht.inMemCache[id.String()]
 	if !ok {
 		return nil, NewErrPeerNotFound(id)

--- a/dht/dht_test.go
+++ b/dht/dht_test.go
@@ -307,8 +307,8 @@ var _ = Describe("DHT", func() {
 
 		It("should only return the PeerAddresses we have when querying with a groupID", func() {
 			test := func() bool {
-				dht := NewDHT(RandomAddress(), NewTable("dht"), nil)
-				peerAddrs := RandomAddresses(rand.Intn(32) + 1)
+				peerAddrs := RandomAddresses(rand.Intn(32) + 2)
+				dht := NewDHT(peerAddrs[0], NewTable("dht"), nil)
 				ids := FromAddressesToIDs(peerAddrs)
 
 				// Purposely not adding the last PeerAddress


### PR DESCRIPTION
Previously this function returned an error of the ID provided was our own.