### PR TITLE
Restrict message lengths

### DIFF
--- a/protocol/message.go
+++ b/protocol/message.go
@@ -24,8 +24,12 @@ type MessageReceiver <-chan MessageOnTheWire
 // MessageLength indicates the length of the entire message.
 type MessageLength uint32
 
-// ValidateMessageVersion checks if the length is valid.
+// ValidateMessageLength checks if the length is valid.
 func ValidateMessageLength(length MessageLength, variant MessageVariant) error {
+	if length > 10*1024*1024 {
+		// TODO: Allow length restriction to be specified as an option.
+		return fmt.Errorf("message length=%v is too big", length)
+	}
 	switch variant {
 	case Cast, Ping, Pong:
 		if int(length) < variant.NonBodyLength() {

--- a/tcp/tcp.go
+++ b/tcp/tcp.go
@@ -170,7 +170,8 @@ func (server *Server) handle(ctx context.Context, conn net.Conn, messages protoc
 	server.logger.Debugf("new connection with %v takes %v", conn.RemoteAddr().String(), time.Now().Sub(now))
 
 	for {
-		messageOtw, err := session.ReadMessageOnTheWire(conn)
+		sizeLimitedReader := io.LimitReader(conn, 10*1024*1024) // Limit incoming connection reads to 10 MB.
+		messageOtw, err := session.ReadMessageOnTheWire(sizeLimitedReader)
 
 		if err != nil {
 			if err != io.EOF {


### PR DESCRIPTION
This PR prevents airwave from accepting messages that are above 10 MB in size. This protects airwave servers from allocating large amounts of memory when large lengths are specified by a malicious client.