### PR TITLE
Protect against bad lengths in handshake

### DIFF
--- a/handshake/handshake.go
+++ b/handshake/handshake.go
@@ -185,6 +185,9 @@ func read(r io.Reader) ([]byte, error) {
 	if err := binary.Read(r, binary.LittleEndian, &dataLen); err != nil {
 		return nil, fmt.Errorf("error reading data len=%v: %v", dataLen, err)
 	}
+	if dataLen > 1024*1024 {
+		return nil, fmt.Errorf("error reading data: len=%v is too big", dataLen)
+	}
 	data := make([]byte, dataLen)
 	if err := binary.Read(r, binary.LittleEndian, &data); err != nil {
 		return data, fmt.Errorf("error reading data: %v", err)

--- a/tcp/conn_test.go
+++ b/tcp/conn_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Connection pool", func() {
 		})
 
 		Context("when reaching max connection limit", func() {
-			FIt("return an error when trying to send messages to new receiver", func() {
+			It("return an error when trying to send messages to new receiver", func() {
 				test := func() bool {
 					ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 					defer func() {

--- a/tcp/conn_test.go
+++ b/tcp/conn_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Connection pool", func() {
 		})
 
 		Context("when reaching max connection limit", func() {
-			It("return an error when trying to send messages to new receiver", func() {
+			FIt("return an error when trying to send messages to new receiver", func() {
 				test := func() bool {
 					ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 					defer func() {
@@ -91,6 +91,9 @@ var _ = Describe("Connection pool", func() {
 
 					_ = NewTCPServer(ctx, ServerOptions{Host: serverAddr1.String()}, clientSignVerifier)
 					_ = NewTCPServer(ctx, ServerOptions{Host: serverAddr2.String()}, clientSignVerifier)
+
+					// Wait for servers to start
+					time.Sleep(100 * time.Millisecond)
 
 					// Expect the second send operation failing due to reaching max number of connections
 					message := RandomMessage(protocol.V1, RandomMessageVariant())


### PR DESCRIPTION
This release make a minor fix that protects handshakers from attempting to allocate large slices during unmarshaling. They are now restricted to 1MB (more than enough for the handshake data).