### PR TITLE
Simplify DHT interface

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -40,13 +40,12 @@ jobs:
                   cd $GITHUB_WORKSPACE
                   CI=true ginkgo --v --race --cover --coverprofile coverprofile.out ./...
                   covermerge                        \
-                    protocol/coverprofile.out       \
                     dht/coverprofile.out            \
-                    cast/coverprofile.out           \
-                    multicast/coverprofile.out      \
-                    broadcast/coverprofile.out      \
-                    pingpong/coverprofile.out       \
+                    gossip/coverprofile.out         \
                     handshake/coverprofile.out      \
                     peer/coverprofile.out           \
-                    tcp/coverprofile.out > coverprofile.out
+                    tcp/coverprofile.out            \
+                    transport/coverprofile.out      \
+                    wire/coverprofile.out           \
+                    wire/wireutil/coverprofile.out > coverprofile.out
                   goveralls -coverprofile=coverprofile.out -service=github

--- a/aw_test.go
+++ b/aw_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Airwave", func() {
 					).
 					Build()
 
-				node1.DHT().InsertAddr(node2.Identity(), node2.Addr())
+				node1.DHT().InsertAddr(node2.Addr())
 
 				go node1.Run(ctx)
 				go node2.Run(ctx)

--- a/dht/dht.go
+++ b/dht/dht.go
@@ -26,7 +26,7 @@ type DHT interface {
 
 	// InsertAddr into the DHT. Returns true if the address is new, otherwise
 	// returns false.
-	InsertAddr(id.Signatory, wire.Address) bool
+	InsertAddr(wire.Address) bool
 	// DeleteAddr from the DHT.
 	DeleteAddr(id.Signatory)
 	// Addr returns the address associated with a signatory. If there is no
@@ -95,9 +95,15 @@ func New(identity id.Signatory) DHT {
 
 // InsertAddr into the DHT. Returns true if the address is new, otherwise
 // returns false.
-func (dht *distributedHashTable) InsertAddr(signatory id.Signatory, addr wire.Address) bool {
+func (dht *distributedHashTable) InsertAddr(addr wire.Address) bool {
 	dht.addrsBySignatoryMu.Lock()
 	defer dht.addrsBySignatoryMu.Unlock()
+
+	signatory, err := addr.Signatory()
+	if err != nil {
+		// If there is an error fetching the signatory, return false.
+		return false
+	}
 
 	existingAddr, ok := dht.addrsBySignatory[signatory]
 	if ok {

--- a/peer/peer.go
+++ b/peer/peer.go
@@ -1,7 +1,6 @@
 package peer
 
 import (
-	"bytes"
 	"context"
 	"crypto/ecdsa"
 	"fmt"
@@ -156,7 +155,7 @@ func (peer *Peer) DidReceivePing(version uint8, data []byte, from id.Signatory) 
 		return wire.Message{}, fmt.Errorf("unsupported remote address: %v", err)
 	}
 
-	if peer.dht.InsertAddr(from, remoteAddr) {
+	if peer.dht.InsertAddr(remoteAddr) {
 		peer.opts.Logger.Infof("peer found with remote address=%v", remoteAddr)
 	}
 
@@ -208,15 +207,8 @@ func (peer *Peer) DidReceivePingAck(version uint8, data []byte, from id.Signator
 
 	// Add all of the remote addresses to the DHT and keep track of the
 	// addresses that we are seeing for the first time.
-	buf := new(bytes.Buffer)
 	for _, addr := range pingAckV1.Addrs {
-		buf.Reset()
-		remoteSignatory, err := addr.SignatoryWithBuffer(buf)
-		if err != nil {
-			peer.opts.Logger.Warnf("identifying remote address=%v: %v", addr, err)
-			continue
-		}
-		if peer.dht.InsertAddr(remoteSignatory, addr) {
+		if peer.dht.InsertAddr(addr) {
 			newRemoteAddrs = append(newRemoteAddrs, addr)
 		}
 	}


### PR DESCRIPTION
The `id.Signatory` parameter in the `InsertAddr` function interface is redundant as the signatory is accessible from `wire.Address`.