### PR TITLE
Fix Wire format and client dial issues

### DIFF
--- a/aw.go
+++ b/aw.go
@@ -15,6 +15,10 @@ import (
 	"go.uber.org/zap"
 )
 
+type (
+	ContentResolver = dht.ContentResolver
+)
+
 type Builder struct {
 	opts Options
 
@@ -155,6 +159,10 @@ func (node *Node) Peer() *peer.Peer {
 
 func (node *Node) Gossiper() *gossip.Gossiper {
 	return node.gossiper
+}
+
+func (node *Node) Sync(ctx context.Context, subnet, hash id.Hash, dataType uint8) ([]byte, error) {
+	return node.gossiper.Sync(ctx, subnet, hash, dataType)
 }
 
 func (node *Node) Identity() id.Signatory {

--- a/aw.go
+++ b/aw.go
@@ -75,10 +75,12 @@ func (builder *Builder) WithAddr(addr wire.Address) *Builder {
 	}
 	return builder
 }
+
 func (builder *Builder) WithHost(host string) *Builder {
 	builder.trans.TCPServerOpts = builder.trans.TCPServerOpts.WithHost(host)
 	return builder
 }
+
 func (builder *Builder) WithPort(port uint16) *Builder {
 	builder.trans.TCPServerOpts = builder.trans.TCPServerOpts.WithPort(port)
 	return builder

--- a/aw_test.go
+++ b/aw_test.go
@@ -39,6 +39,7 @@ var _ = Describe("Airwave", func() {
 				privKey1 := id.NewPrivKey()
 				Expect(addr1.Sign(privKey1)).To(Succeed())
 				node1 := aw.New().
+					WithPrivKey(privKey1).
 					WithAddr(addr1).
 					WithHost("0.0.0.0").
 					WithPort(port1).
@@ -49,6 +50,7 @@ var _ = Describe("Airwave", func() {
 				privKey2 := id.NewPrivKey()
 				Expect(addr2.Sign(privKey2)).To(Succeed())
 				node2 := aw.New().
+					WithPrivKey(privKey2).
 					WithAddr(addr2).
 					WithHost("0.0.0.0").
 					WithPort(port2).

--- a/aw_test.go
+++ b/aw_test.go
@@ -1,7 +1,9 @@
 package aw_test
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"math/rand"
 	"sync/atomic"
@@ -90,6 +92,71 @@ var _ = Describe("Airwave", func() {
 				Expect(didReceiveN).To(Equal(willSendN))
 				Expect(didReceiveOnce).To(BeTrue())
 				Expect(didReceiveDone).To(BeTrue())
+			})
+		})
+	})
+
+	Context("when gossiping", func() {
+		Context("when fully connected", func() {
+			FIt("should return content from all nodes", func() {
+				defer time.Sleep(time.Millisecond)
+
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+
+				// Initialise nodes.
+				n := 3
+				nodes := make([]*aw.Node, n)
+				for i := range nodes {
+					port := uint16(3000 + i)
+					node := aw.New().
+						WithAddr(wire.NewUnsignedAddress(wire.TCP, fmt.Sprintf("0.0.0.0:%v", port), uint64(time.Now().UnixNano()))).
+						WithHost("0.0.0.0").
+						WithPort(port).
+						Build()
+					nodes[i] = node
+				}
+
+				// Connect nodes in a fully connected cyclic graph.
+				for i := range nodes {
+					for j := range nodes {
+						if i == j {
+							continue
+						}
+						nodes[i].DHT().InsertAddr(nodes[j].Addr())
+					}
+				}
+
+				// Run the nodes.
+				for i := range nodes {
+					go nodes[i].Run(ctx)
+				}
+
+				// Sleep for enough time for nodes to find each other by pinging
+				// each other.
+				time.Sleep(100 * time.Millisecond)
+
+				contentHash := sha256.Sum256([]byte("hello!"))
+				contentType := uint8(1)
+				content := []byte("hello!")
+				// nodes[0].Broadcast(ctx, gossip.DefaultSubnet, contentType, content)
+
+				found := map[id.Signatory]struct{}{}
+				for {
+					time.Sleep(time.Millisecond)
+					for i := range nodes {
+						data, ok := nodes[i].DHT().Content(contentHash, contentType)
+						if !ok {
+							continue
+						}
+						if bytes.Equal(content, data) {
+							found[nodes[i].Identity()] = struct{}{}
+						}
+					}
+					if len(found) == n {
+						return
+					}
+				}
 			})
 		})
 	})

--- a/aw_test.go
+++ b/aw_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Airwave", func() {
 				defer cancel()
 
 				// Initialise nodes.
-				n := 2
+				n := 3
 				nodes := make([]*aw.Node, n)
 				addrs := make([]wire.Address, n)
 				for i := range nodes {

--- a/handshake/ecdsa.go
+++ b/handshake/ecdsa.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
+	"log"
 	"net"
 	"time"
 
@@ -34,6 +35,7 @@ func (handshaker *ecdsaHandshaker) Handshake(ctx context.Context, conn net.Conn)
 	if err := conn.SetWriteDeadline(time.Now().Add(handshaker.opts.Timeout / 4)); err != nil {
 		return nil, fmt.Errorf("setting deadline: %v", err)
 	}
+	log.Println("[Handshake] writing pubkey with signature")
 	if err := writePubKeyWithSignature(conn, &handshaker.opts.PrivKey.PublicKey, handshaker.opts.PrivKey); err != nil {
 		return nil, fmt.Errorf("writing client pubkey with signature: %v", err)
 	}
@@ -44,6 +46,7 @@ func (handshaker *ecdsaHandshaker) Handshake(ctx context.Context, conn net.Conn)
 	if err := conn.SetReadDeadline(time.Now().Add(handshaker.opts.Timeout / 4)); err != nil {
 		return nil, fmt.Errorf("setting deadline: %v", err)
 	}
+	log.Println("[Handshake] reading pubkey with signature")
 	serverPubKey, serverSignatory, err := readPubKeyWithSignature(conn)
 	if err != nil {
 		return nil, fmt.Errorf("reading server pubkey with signature: %v", err)
@@ -95,8 +98,7 @@ func (handshaker *ecdsaHandshaker) AcceptHandshake(ctx context.Context, conn net
 	//
 	// 2
 	//
-	err = writePubKeyWithSignature(conn, &handshaker.opts.PrivKey.PublicKey, handshaker.opts.PrivKey)
-	if err != nil {
+	if err := writePubKeyWithSignature(conn, &handshaker.opts.PrivKey.PublicKey, handshaker.opts.PrivKey); err != nil {
 		return nil, fmt.Errorf("writing server pubkey with signature: %v", err)
 	}
 

--- a/handshake/ecdsa.go
+++ b/handshake/ecdsa.go
@@ -6,7 +6,6 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
-	"log"
 	"net"
 	"time"
 
@@ -35,7 +34,6 @@ func (handshaker *ecdsaHandshaker) Handshake(ctx context.Context, conn net.Conn)
 	if err := conn.SetWriteDeadline(time.Now().Add(handshaker.opts.Timeout / 4)); err != nil {
 		return nil, fmt.Errorf("setting deadline: %v", err)
 	}
-	log.Println("[Handshake] writing pubkey with signature")
 	if err := writePubKeyWithSignature(conn, &handshaker.opts.PrivKey.PublicKey, handshaker.opts.PrivKey); err != nil {
 		return nil, fmt.Errorf("writing client pubkey with signature: %v", err)
 	}
@@ -46,7 +44,6 @@ func (handshaker *ecdsaHandshaker) Handshake(ctx context.Context, conn net.Conn)
 	if err := conn.SetReadDeadline(time.Now().Add(handshaker.opts.Timeout / 4)); err != nil {
 		return nil, fmt.Errorf("setting deadline: %v", err)
 	}
-	log.Println("[Handshake] reading pubkey with signature")
 	serverPubKey, serverSignatory, err := readPubKeyWithSignature(conn)
 	if err != nil {
 		return nil, fmt.Errorf("reading server pubkey with signature: %v", err)


### PR DESCRIPTION
- Use streaming on wire Message type
- Use 1024 bytes for client/server readers/writers instead of `surge.MaxBytes`
- Ensure re-dial attempts only occur after a set amount of time
- Fix bug allowing maximum dial attempts to be subverted
- Export methods/interfaces at higher levels