### PR TITLE
Do not force insertion when casting/broadcasting content

### DIFF
--- a/aw.go
+++ b/aw.go
@@ -135,13 +135,11 @@ func (node *Node) Run(ctx context.Context) {
 
 func (node *Node) Send(ctx context.Context, signatory id.Signatory, dataType uint8, data []byte) {
 	hash := sha256.Sum256(data)
-	node.dht.InsertContent(hash, dataType, data)
 	node.gossiper.Gossip(id.Hash(signatory), hash, dataType)
 }
 
 func (node *Node) Broadcast(ctx context.Context, subnet id.Hash, dataType uint8, data []byte) {
 	hash := sha256.Sum256(data)
-	node.dht.InsertContent(hash, dataType, data)
 	node.gossiper.Gossip(subnet, hash, dataType)
 }
 


### PR DESCRIPTION
This allows for the user to have more control over when data is inserted, and prevents inserting duplicate data multiple times.