### PR TITLE
test wire Address' signature recovery

### DIFF
--- a/wire/addr_test.go
+++ b/wire/addr_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/renproject/aw/wire"
 	"github.com/renproject/aw/wire/wireutil"
+	"github.com/renproject/id"
 	"github.com/renproject/surge"
 
 	. "github.com/onsi/ginkgo"
@@ -25,6 +26,22 @@ var _ = Describe("Address", func() {
 				err = surge.FromBinary(&unmarshaledAddr, data)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(addr.Equal(&unmarshaledAddr)).To(BeTrue())
+				return true
+			}
+			Expect(quick.Check(f, nil)).To(Succeed())
+		})
+	})
+
+	Context("when recovering signature", func() {
+		It("should be the correct signatory", func() {
+			f := func() bool {
+				pk := id.NewPrivKey()
+				expectedSignatory := pk.Signatory()
+				wireAddress := wire.NewUnsignedAddress(wire.TCP, "0.0.0.0", uint64(time.Now().UnixNano()))
+				wireAddress.Sign(pk)
+				recoveredSignatory, err := wireAddress.Signatory()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(recoveredSignatory.Equal(&expectedSignatory)).To(BeTrue())
 				return true
 			}
 			Expect(quick.Check(f, nil)).To(Succeed())


### PR DESCRIPTION
Encountered a discrepancy in:
1. priv key signatory
2. wire address signature recovery
in darknode config files.

So added a test just to make sure everything is right on `wire.Address`'s side.