### PR TITLE
Remove custom TCP server overrides

### DIFF
--- a/aw.go
+++ b/aw.go
@@ -94,16 +94,6 @@ func (builder *Builder) WithAddr(addr wire.Address) *Builder {
 	return builder
 }
 
-func (builder *Builder) WithHost(host string) *Builder {
-	builder.trans.TCPServerOpts = builder.trans.TCPServerOpts.WithHost(host)
-	return builder
-}
-
-func (builder *Builder) WithPort(port uint16) *Builder {
-	builder.trans.TCPServerOpts = builder.trans.TCPServerOpts.WithPort(port)
-	return builder
-}
-
 func (builder *Builder) WithTCPClientOptions(opts tcp.ClientOptions) *Builder {
 	builder.trans.TCPClientOpts = opts
 	return builder

--- a/aw_test.go
+++ b/aw_test.go
@@ -56,8 +56,7 @@ var _ = Describe("Airwave", func() {
 					WithPrivKey(privKey1).
 					WithAddr(addr1).
 					WithTCPClientOptions(tcpClientOpts).
-					WithTCPServerOptions(tcpServerOpts).
-					WithPort(port1).
+					WithTCPServerOptions(tcpServerOpts.WithPort(port1)).
 					WithLogger(logger).
 					Build()
 
@@ -70,8 +69,7 @@ var _ = Describe("Airwave", func() {
 					WithPrivKey(privKey2).
 					WithAddr(addr2).
 					WithTCPClientOptions(tcpClientOpts).
-					WithTCPServerOptions(tcpServerOpts).
-					WithPort(port2).
+					WithTCPServerOptions(tcpServerOpts.WithPort(port2)).
 					WithContentResolver(
 						dht.NewDoubleCacheContentResolver(dht.DefaultDoubleCacheContentResolverOptions(), dht.CallbackContentResolver{
 							InsertCallback: func(hash id.Hash, contentType uint8, content []byte) {
@@ -167,8 +165,7 @@ var _ = Describe("Airwave", func() {
 						WithPrivKey(privKey).
 						WithAddr(addrs[i]).
 						WithTCPClientOptions(tcpClientOpts).
-						WithTCPServerOptions(tcpServerOpts).
-						WithPort(port).
+						WithTCPServerOptions(tcpServerOpts.WithPort(port)).
 						WithLogger(logger).
 						Build()
 

--- a/wire/addr.go
+++ b/wire/addr.go
@@ -217,6 +217,9 @@ func (addr *Address) Equal(other *Address) bool {
 // DecodeString into a wire-compatible Address.
 func DecodeString(addr string) (Address, error) {
 	addrParts := strings.Split(addr, "/")
+	if len(addrParts) != 5 {
+		return Address{}, fmt.Errorf("decoding string: invalid format=%v", addr)
+	}
 	var protocol uint8
 	switch addrParts[1] {
 	case "tcp":

--- a/wire/addr.go
+++ b/wire/addr.go
@@ -216,12 +216,17 @@ func (addr *Address) Equal(other *Address) bool {
 
 // DecodeString into a wire-compatible Address.
 func DecodeString(addr string) (Address, error) {
+	// Remove any leading slashes.
+	if addr[:1] == "/" {
+		addr = addr[1:]
+	}
+
 	addrParts := strings.Split(addr, "/")
-	if len(addrParts) != 5 {
+	if len(addrParts) != 4 {
 		return Address{}, fmt.Errorf("decoding string: invalid format=%v", addr)
 	}
 	var protocol uint8
-	switch addrParts[1] {
+	switch addrParts[0] {
 	case "tcp":
 		protocol = TCP
 	case "udp":
@@ -229,13 +234,13 @@ func DecodeString(addr string) (Address, error) {
 	case "ws":
 		protocol = WebSocket
 	}
-	value := addrParts[2]
-	nonce, err := strconv.ParseUint(addrParts[3], 10, 64)
+	value := addrParts[1]
+	nonce, err := strconv.ParseUint(addrParts[2], 10, 64)
 	if err != nil {
 		return Address{}, err
 	}
 	var sig id.Signature
-	sigBytes, err := base64.RawURLEncoding.DecodeString(addrParts[4])
+	sigBytes, err := base64.RawURLEncoding.DecodeString(addrParts[3])
 	if err != nil {
 		return Address{}, err
 	}

--- a/wire/addr_test.go
+++ b/wire/addr_test.go
@@ -30,4 +30,19 @@ var _ = Describe("Address", func() {
 			Expect(quick.Check(f, nil)).To(Succeed())
 		})
 	})
+
+	Context("when stringifying and decoding", func() {
+		It("should equal itself", func() {
+			f := func() bool {
+				r := rand.New(rand.NewSource(time.Now().UnixNano()))
+				addr := wireutil.NewAddressBuilder(wireutil.RandomPrivKey(), r).Build()
+				addrString := addr.String()
+				decodedAddr, err := wire.DecodeString(addrString)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(decodedAddr.Equal(&addr)).To(BeTrue())
+				return true
+			}
+			Expect(quick.Check(f, nil)).To(Succeed())
+		})
+	})
 })

--- a/wire/addr_test.go
+++ b/wire/addr_test.go
@@ -40,6 +40,12 @@ var _ = Describe("Address", func() {
 				decodedAddr, err := wire.DecodeString(addrString)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(decodedAddr.Equal(&addr)).To(BeTrue())
+
+				// Remove the leading slash and make sure it still succeeds.
+				addrString = addrString[1:]
+				decodedAddr, err = wire.DecodeString(addrString)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(decodedAddr.Equal(&addr)).To(BeTrue())
 				return true
 			}
 			Expect(quick.Check(f, nil)).To(Succeed())

--- a/wire/addr_test.go
+++ b/wire/addr_test.go
@@ -47,10 +47,11 @@ var _ = Describe("Address", func() {
 				decodedAddr, err = wire.DecodeString(addrString)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(decodedAddr.Equal(&addr)).To(BeTrue())
-        return true
+				return true
 			}
 			Expect(quick.Check(f, nil)).To(Succeed())
 		})
+	})
 
 	Context("when recovering signature", func() {
 		It("should be the correct signatory", func() {


### PR DESCRIPTION
This PR simplifies the builder to prevent host/port overrides now that custom TCP options are allowed. Currently the user is able to call `builder.WithHost().WithTCPServerOptions()` which overrides the custom host with the default.

Additionally, we add a string decoder function for convenience.