### PR TITLE
Refactor sendToSubnet to use a Linked List of signatories instead of an array

### DIFF
--- a/gossip/gossip.go
+++ b/gossip/gossip.go
@@ -331,7 +331,6 @@ func (g *Gossiper) DidReceivePullAck(version wire.Version, data []byte, from id.
 }
 
 func (g *Gossiper) sendToSubnet(subnet id.Hash, msg wire.Message) {
-	// var subnetSignatories []id.Signatory
 	subnetSignatories := list.New()
 	if subnet == DefaultSubnet {
 		// If the default subnet hash is provided, return a random subset of all


### PR DESCRIPTION
- [ ] Top level description
- [ ] Testing
  - [ ] Correctness
  - [ ] Perf