### PR TITLE
BUG: Fix incorrect deletion from addrsSorted

### DIFF
--- a/dht/dht.go
+++ b/dht/dht.go
@@ -192,17 +192,6 @@ func (dht *distributedHashTable) DeleteAddr(signatory id.Signatory) {
 		if expectedSig.Equal(&signatory) {
 			dht.addrsSorted = append(dht.addrsSorted[:removeIndex], dht.addrsSorted[removeIndex+1:]...)
 		}
-	} else if numAddrs > 0 {
-		expectedSig, err := dht.addrsSorted[numAddrs-1].Signatory()
-		if err != nil {
-			// This should not be possible as only addresses with valid
-			// signatories are inserted into the DHT.
-			return
-		}
-
-		if expectedSig.Equal(&signatory) {
-			dht.addrsSorted = dht.addrsSorted[:numAddrs-1]
-		}
 	}
 }
 

--- a/dht/dht.go
+++ b/dht/dht.go
@@ -181,7 +181,7 @@ func (dht *distributedHashTable) DeleteAddr(signatory id.Signatory) {
 	})
 
 	removeIndex := i - 1
-	if removeIndex >= 0 && removeIndex < numAddrs {
+	if removeIndex >= 0 {
 		expectedSig, err := dht.addrsSorted[removeIndex].Signatory()
 		if err != nil {
 			// This should not be possible as only addresses with valid

--- a/dht/dht_test.go
+++ b/dht/dht_test.go
@@ -284,6 +284,78 @@ var _ = Describe("DHT", func() {
 		})
 	})
 
+	Context("when deleting an address at end of array", func() {
+		It("should not be present in sorted addresses", func() {
+			table, _ := initDHT()
+			numAddrs := 10
+
+			for i := 0; i < numAddrs; i++ {
+				privKey := id.NewPrivKey()
+				randAddr := wireutil.NewAddressBuilder(
+					privKey,
+					rand.New(rand.NewSource(GinkgoRandomSeed()+1)),
+				).Build()
+
+				ok := table.InsertAddr(randAddr)
+				Expect(ok).To(BeTrue())
+			}
+
+			// Get sorted addresses and check if they are equal
+			// to the number of inserted addresses
+			addrs := table.Addrs(numAddrs)
+			Expect(len(addrs)).To(Equal(numAddrs))
+
+			// Remove last addresses, query sorted addresses again
+			// and check if they are equal to the number of addresses
+			// sans 1
+			addrToDelete := addrs[numAddrs-1]
+			sig, err := addrToDelete.Signatory()
+			Expect(err).To(BeNil())
+
+			table.DeleteAddr(sig)
+			addrs = table.Addrs(numAddrs - 1)
+			Expect(len(addrs)).To(Equal(numAddrs - 1))
+
+			Expect(addrs[numAddrs-2].Equal(&addrToDelete)).To(Equal(false))
+		})
+	})
+
+	Context("when deleting an address at start of array", func() {
+		It("should not be present in sorted addresses", func() {
+			table, _ := initDHT()
+			numAddrs := 10
+
+			for i := 0; i < numAddrs; i++ {
+				privKey := id.NewPrivKey()
+				randAddr := wireutil.NewAddressBuilder(
+					privKey,
+					rand.New(rand.NewSource(GinkgoRandomSeed()+1)),
+				).Build()
+
+				ok := table.InsertAddr(randAddr)
+				Expect(ok).To(BeTrue())
+			}
+
+			// Get sorted addresses and check if they are equal
+			// to the number of inserted addresses
+			addrs := table.Addrs(numAddrs)
+			Expect(len(addrs)).To(Equal(numAddrs))
+
+			// Remove last addresses, query sorted addresses again
+			// and check if they are equal to the number of addresses
+			// sans 1
+			addrToDelete := addrs[0]
+			sig, err := addrToDelete.Signatory()
+			Expect(err).To(BeNil())
+
+			table.DeleteAddr(sig)
+			addrs = table.Addrs(numAddrs - 1)
+			Expect(len(addrs)).To(Equal(numAddrs - 1))
+
+			Expect(addrs[0].Equal(&addrToDelete)).To(Equal(false))
+		})
+	})
+
 	Describe("Content", func() {
 		Context("when initialising a DHT without a content resolver", func() {
 			It("should panic", func() {

--- a/dht/dht_test.go
+++ b/dht/dht_test.go
@@ -134,6 +134,128 @@ var _ = Describe("DHT", func() {
 			})
 		})
 
+		Context("when deleting an address at start of array", func() {
+			It("should not be present in sorted addresses", func() {
+				table, _ := initDHT()
+				numAddrs := 10
+
+				for i := 0; i < numAddrs; i++ {
+					privKey := id.NewPrivKey()
+					randAddr := wireutil.NewAddressBuilder(
+						privKey,
+						rand.New(rand.NewSource(GinkgoRandomSeed()+1)),
+					).Build()
+
+					ok := table.InsertAddr(randAddr)
+					Expect(ok).To(BeTrue())
+				}
+
+				// Get sorted addresses and check if they are equal
+				// to the number of inserted addresses
+				addrs := table.Addrs(numAddrs)
+				Expect(len(addrs)).To(Equal(numAddrs))
+
+				// Remove last addresses, query sorted addresses again
+				// and check if they are equal to the number of addresses
+				// sans 1
+				addrToDelete := addrs[0]
+				sig, err := addrToDelete.Signatory()
+				Expect(err).To(BeNil())
+
+				table.DeleteAddr(sig)
+				addrs = table.Addrs(numAddrs - 1)
+				Expect(len(addrs)).To(Equal(numAddrs - 1))
+
+				Expect(addrs[0].Equal(&addrToDelete)).To(Equal(false))
+			})
+		})
+
+		Context("when deleting an address at end of array", func() {
+			It("should not be present in sorted addresses", func() {
+				table, _ := initDHT()
+				numAddrs := 10
+
+				for i := 0; i < numAddrs; i++ {
+					privKey := id.NewPrivKey()
+					randAddr := wireutil.NewAddressBuilder(
+						privKey,
+						rand.New(rand.NewSource(GinkgoRandomSeed()+1)),
+					).Build()
+
+					ok := table.InsertAddr(randAddr)
+					Expect(ok).To(BeTrue())
+				}
+
+				// Get sorted addresses and check if they are equal
+				// to the number of inserted addresses
+				addrs := table.Addrs(numAddrs)
+				Expect(len(addrs)).To(Equal(numAddrs))
+
+				// Remove last addresses, query sorted addresses again
+				// and check if they are equal to the number of addresses
+				// sans 1
+				addrToDelete := addrs[numAddrs-1]
+				sig, err := addrToDelete.Signatory()
+				Expect(err).To(BeNil())
+
+				table.DeleteAddr(sig)
+				addrs = table.Addrs(numAddrs - 1)
+				Expect(len(addrs)).To(Equal(numAddrs - 1))
+
+				Expect(addrs[numAddrs-2].Equal(&addrToDelete)).To(Equal(false))
+			})
+		})
+
+		Context("when deleting an address", func() {
+			It("should not be present in sorted addresses", func() {
+
+				f := func(seed int64) bool {
+					table, _ := initDHT()
+					numAddrs := rand.Intn(90) + 10 // [10, 100)
+
+					privKey := id.NewPrivKey()
+					addr := wireutil.NewAddressBuilder(
+						privKey,
+						rand.New(rand.NewSource(seed)),
+					).Build()
+
+					// Try to delete the address prior to inserting to make sure
+					// it does not panic.
+					signatory := id.NewSignatory((*id.PubKey)(&privKey.PublicKey))
+					table.DeleteAddr(signatory)
+
+					// Insert random number of addresses
+					for i := 0; i < numAddrs; i++ {
+						privKey := id.NewPrivKey()
+						randAddr := wireutil.NewAddressBuilder(
+							privKey,
+							rand.New(rand.NewSource(GinkgoRandomSeed()+1)),
+						).Build()
+
+						ok := table.InsertAddr(randAddr)
+						Expect(ok).To(BeTrue())
+					}
+
+					// Insert the initial address
+					ok := table.InsertAddr(addr)
+					Expect(ok).To(BeTrue())
+
+					// Delete the address and make sure it no longer exists
+					// in the sorted array of addresses
+					table.DeleteAddr(signatory)
+					Expect(table.NumAddrs()).To(Equal(numAddrs))
+
+					for _, addr2 := range table.Addrs(numAddrs) {
+						if addr.Equal(&addr2) {
+							return false
+						}
+					}
+					return true
+				}
+				Expect(quick.Check(f, nil)).To(Succeed())
+			})
+		})
+
 		Context("when querying addresses", func() {
 			It("should return them in order of their XOR distance", func() {
 				table, identity := initDHT()
@@ -231,128 +353,6 @@ var _ = Describe("DHT", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(n).To(Equal(numAddrs))
 			})
-		})
-
-		Context("when deleting an address", func() {
-			It("should not be present in sorted addresses", func() {
-
-				f := func(seed int64) bool {
-					table, _ := initDHT()
-					numAddrs := rand.Intn(90) + 10 // [10, 100)
-
-					privKey := id.NewPrivKey()
-					addr := wireutil.NewAddressBuilder(
-						privKey,
-						rand.New(rand.NewSource(seed)),
-					).Build()
-
-					// Try to delete the address prior to inserting to make sure
-					// it does not panic.
-					signatory := id.NewSignatory((*id.PubKey)(&privKey.PublicKey))
-					table.DeleteAddr(signatory)
-
-					// Insert random number of addresses
-					for i := 0; i < numAddrs; i++ {
-						privKey := id.NewPrivKey()
-						randAddr := wireutil.NewAddressBuilder(
-							privKey,
-							rand.New(rand.NewSource(GinkgoRandomSeed()+1)),
-						).Build()
-
-						ok := table.InsertAddr(randAddr)
-						Expect(ok).To(BeTrue())
-					}
-
-					// Insert the initial address
-					ok := table.InsertAddr(addr)
-					Expect(ok).To(BeTrue())
-
-					// Delete the address and make sure it no longer exists
-					// in the sorted array of addresses
-					table.DeleteAddr(signatory)
-					Expect(table.NumAddrs()).To(Equal(numAddrs))
-
-					for _, addr2 := range table.Addrs(numAddrs) {
-						if addr.Equal(&addr2) {
-							return false
-						}
-					}
-					return true
-				}
-				Expect(quick.Check(f, nil)).To(Succeed())
-			})
-		})
-	})
-
-	Context("when deleting an address at end of array", func() {
-		It("should not be present in sorted addresses", func() {
-			table, _ := initDHT()
-			numAddrs := 10
-
-			for i := 0; i < numAddrs; i++ {
-				privKey := id.NewPrivKey()
-				randAddr := wireutil.NewAddressBuilder(
-					privKey,
-					rand.New(rand.NewSource(GinkgoRandomSeed()+1)),
-				).Build()
-
-				ok := table.InsertAddr(randAddr)
-				Expect(ok).To(BeTrue())
-			}
-
-			// Get sorted addresses and check if they are equal
-			// to the number of inserted addresses
-			addrs := table.Addrs(numAddrs)
-			Expect(len(addrs)).To(Equal(numAddrs))
-
-			// Remove last addresses, query sorted addresses again
-			// and check if they are equal to the number of addresses
-			// sans 1
-			addrToDelete := addrs[numAddrs-1]
-			sig, err := addrToDelete.Signatory()
-			Expect(err).To(BeNil())
-
-			table.DeleteAddr(sig)
-			addrs = table.Addrs(numAddrs - 1)
-			Expect(len(addrs)).To(Equal(numAddrs - 1))
-
-			Expect(addrs[numAddrs-2].Equal(&addrToDelete)).To(Equal(false))
-		})
-	})
-
-	Context("when deleting an address at start of array", func() {
-		It("should not be present in sorted addresses", func() {
-			table, _ := initDHT()
-			numAddrs := 10
-
-			for i := 0; i < numAddrs; i++ {
-				privKey := id.NewPrivKey()
-				randAddr := wireutil.NewAddressBuilder(
-					privKey,
-					rand.New(rand.NewSource(GinkgoRandomSeed()+1)),
-				).Build()
-
-				ok := table.InsertAddr(randAddr)
-				Expect(ok).To(BeTrue())
-			}
-
-			// Get sorted addresses and check if they are equal
-			// to the number of inserted addresses
-			addrs := table.Addrs(numAddrs)
-			Expect(len(addrs)).To(Equal(numAddrs))
-
-			// Remove last addresses, query sorted addresses again
-			// and check if they are equal to the number of addresses
-			// sans 1
-			addrToDelete := addrs[0]
-			sig, err := addrToDelete.Signatory()
-			Expect(err).To(BeNil())
-
-			table.DeleteAddr(sig)
-			addrs = table.Addrs(numAddrs - 1)
-			Expect(len(addrs)).To(Equal(numAddrs - 1))
-
-			Expect(addrs[0].Equal(&addrToDelete)).To(Equal(false))
 		})
 	})
 

--- a/dht/dht_test.go
+++ b/dht/dht_test.go
@@ -161,11 +161,11 @@ var _ = Describe("DHT", func() {
 				addrToDelete := addrs[0]
 				sig, err := addrToDelete.Signatory()
 				Expect(err).To(BeNil())
-
 				table.DeleteAddr(sig)
 				addrs = table.Addrs(numAddrs - 1)
 				Expect(len(addrs)).To(Equal(numAddrs - 1))
 
+				// Check if the address still exists in array
 				Expect(addrs[0].Equal(&addrToDelete)).To(Equal(false))
 			})
 		})
@@ -197,11 +197,11 @@ var _ = Describe("DHT", func() {
 				addrToDelete := addrs[numAddrs-1]
 				sig, err := addrToDelete.Signatory()
 				Expect(err).To(BeNil())
-
 				table.DeleteAddr(sig)
 				addrs = table.Addrs(numAddrs - 1)
 				Expect(len(addrs)).To(Equal(numAddrs - 1))
 
+				// Check if the address still exists in array
 				Expect(addrs[numAddrs-2].Equal(&addrToDelete)).To(Equal(false))
 			})
 		})

--- a/dht/dht_test.go
+++ b/dht/dht_test.go
@@ -155,7 +155,7 @@ var _ = Describe("DHT", func() {
 				addrs := table.Addrs(numAddrs)
 				Expect(len(addrs)).To(Equal(numAddrs))
 
-				// Remove last addresses, query sorted addresses again
+				// Remove first addresses, query sorted addresses again
 				// and check if they are equal to the number of addresses
 				// sans 1
 				addrToDelete := addrs[0]

--- a/dht/dht_test.go
+++ b/dht/dht_test.go
@@ -270,7 +270,6 @@ var _ = Describe("DHT", func() {
 					// Delete the address and make sure it no longer exists
 					// in the sorted array of addresses
 					table.DeleteAddr(signatory)
-
 					Expect(table.NumAddrs()).To(Equal(numAddrs))
 
 					for _, addr2 := range table.Addrs(numAddrs) {
@@ -278,7 +277,6 @@ var _ = Describe("DHT", func() {
 							return false
 						}
 					}
-
 					return true
 				}
 				Expect(quick.Check(f, nil)).To(Succeed())


### PR DESCRIPTION
When deleting an address, the wrong index was being deleted, and if the address to be deleted was present at the end of the array, was not being deleted at all. This was leading to disparity between the `addrsBySignatory` hashmap and `addrsSorted` array. This PR fixes that and adds a correctness test to `dht_test.go`

- [x] Correctness tests (might need more)

This bug affects gossiping as well since `dht.Addrs(n)` uses  `addrsSorted`