### PR TITLE
GCM nonce fix

### DIFF
--- a/codec/gcm.go
+++ b/codec/gcm.go
@@ -92,7 +92,7 @@ func GCMEncoder(session *GCMSession, enc Encoder) Encoder {
 		encoded := session.gcm.Seal(nil, nonceBuf[:], buf, nil)
 		n, err := enc(w, encoded)
 		if err != nil {
-			return n, fmt.Errorf("Encoded sealed data: %v", err)
+			return 0, fmt.Errorf("encoding sealed data: %v", err)
 		}
 		return len(buf), nil
 	}

--- a/codec/gcm.go
+++ b/codec/gcm.go
@@ -1,26 +1,58 @@
 package codec
 
 import (
+	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
-	"encoding/binary"
 	"fmt"
 	"io"
-	"math/rand"
+	"math"
+
+	"github.com/renproject/id"
+	"github.com/renproject/surge"
 )
 
+type gcmNonce struct {
+	top       uint32
+	bottom    uint64
+	countDown bool
+}
+
+func (nonce *gcmNonce) change() {
+	if nonce.countDown {
+		nonce.pred()
+	} else {
+		nonce.succ()
+	}
+
+}
+
+func (nonce *gcmNonce) succ() {
+	nonce.bottom += 1
+	if nonce.bottom == 0 {
+		nonce.top += 1
+	}
+}
+
+func (nonce *gcmNonce) pred() {
+	nonce.bottom -= 1
+	if nonce.bottom == math.MaxUint64 {
+		nonce.top -= 1
+	}
+}
+
 // A GCMSession stores the state of a GCM authenticated/encrypted session. This
+
 // includes the read/write nonces, memory buffers, and the GCM cipher itself.
 type GCMSession struct {
-	gcm       cipher.AEAD
-	wRand     *rand.Rand
-	wBuf      []byte
-	nonceSize int
+	gcm        cipher.AEAD
+	readNonce  *gcmNonce
+	writeNonce *gcmNonce
 }
 
 // NewGCMSession accepts a symmetric secret key and returns a new GCMSession
 // that is configured using the symmetric secret key.
-func NewGCMSession(key [32]byte) (*GCMSession, error) {
+func NewGCMSession(key [32]byte, self, remote id.Signatory) (*GCMSession, error) {
 	block, err := aes.NewCipher(key[:])
 	if err != nil {
 		return &GCMSession{}, fmt.Errorf("creating aes cipher: %v", err)
@@ -29,23 +61,42 @@ func NewGCMSession(key [32]byte) (*GCMSession, error) {
 	if err != nil {
 		return &GCMSession{}, fmt.Errorf("creating gcm cipher: %v", err)
 	}
-	return &GCMSession{
-		gcm:       gcm,
-		wRand:     rand.New(rand.NewSource(int64(binary.BigEndian.Uint64(key[:8])))),
-		wBuf:      make([]byte, gcm.NonceSize()),
-		nonceSize: gcm.NonceSize(),
-	}, nil
+
+	gcmSession := &GCMSession{
+		gcm:        gcm,
+		readNonce:  &gcmNonce{},
+		writeNonce: &gcmNonce{},
+	}
+
+	if bytes.Compare(self[:], remote[:]) < 0 {
+		gcmSession.writeNonce.top = math.MaxUint32
+		gcmSession.writeNonce.bottom = math.MaxUint64
+		gcmSession.writeNonce.countDown = true
+	} else {
+		gcmSession.readNonce.top = math.MaxUint32
+		gcmSession.readNonce.bottom = math.MaxUint64
+		gcmSession.readNonce.countDown = true
+
+	}
+	return gcmSession, nil
 }
 
 func GCMEncoder(session *GCMSession, enc Encoder) Encoder {
 	return func(w io.Writer, buf []byte) (int, error) {
-		_, err := session.wRand.Read(session.wBuf)
+		nonceBufTop, err := surge.ToBinary(session.writeNonce.top)
 		if err != nil {
-			return 0, fmt.Errorf("generating randomness: %v", err)
+			return 0, fmt.Errorf("marshaling nonce to bytes: %v", err)
 		}
-		n, err := enc(w, append(session.wBuf, session.gcm.Seal(nil, session.wBuf, buf, nil)...))
+		nonceBufBottom, err := surge.ToBinary(session.writeNonce.bottom)
 		if err != nil {
-			return n, fmt.Errorf("encoding sealed data: %v", err)
+			return 0, fmt.Errorf("marshaling nonce to bytes: %v", err)
+		}
+		nonceBuf := append(nonceBufTop, nonceBufBottom...)
+		session.writeNonce.change()
+		encoded := session.gcm.Seal(nil, nonceBuf, buf, nil)
+		n, err := enc(w, encoded)
+		if err != nil {
+			return n, fmt.Errorf("Encoded sealed data: %v", err)
 		}
 		return n, nil
 	}
@@ -57,7 +108,18 @@ func GCMDecoder(session *GCMSession, dec Decoder) Decoder {
 		if err != nil {
 			return n, fmt.Errorf("decoding data: %v", err)
 		}
-		decrypted, err := session.gcm.Open(nil, buf[:session.nonceSize], buf[session.nonceSize:n], nil)
+		nonceBufTop, err := surge.ToBinary(session.readNonce.top)
+		if err != nil {
+			return 0, fmt.Errorf("marshaling nonce to bytes: %v", err)
+		}
+		nonceBufBottom, err := surge.ToBinary(session.readNonce.bottom)
+		if err != nil {
+			return 0, fmt.Errorf("marshaling nonce to bytes: %v", err)
+		}
+		nonceBuf := append(nonceBufTop, nonceBufBottom...)
+		session.readNonce.change()
+		decrypted, err := session.gcm.Open(nil, nonceBuf, buf[:n], nil)
+
 		if err != nil {
 			return 0, fmt.Errorf("opening sealed data: %v", err)
 		}

--- a/codec/gcm.go
+++ b/codec/gcm.go
@@ -4,21 +4,22 @@ import (
 	"bytes"
 	"crypto/aes"
 	"crypto/cipher"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"math"
 
 	"github.com/renproject/id"
-	"github.com/renproject/surge"
 )
 
 type gcmNonce struct {
+	// top and bottom together represent the top 32 bits and bottom 64 bits of a 96 bit unsigned integer
 	top       uint32
 	bottom    uint64
 	countDown bool
 }
 
-func (nonce *gcmNonce) change() {
+func (nonce gcmNonce) next() {
 	if nonce.countDown {
 		nonce.pred()
 	} else {
@@ -27,27 +28,28 @@ func (nonce *gcmNonce) change() {
 
 }
 
-func (nonce *gcmNonce) succ() {
+func (nonce gcmNonce) succ() {
 	nonce.bottom += 1
+	// If bottom overflows, increment top by 1
 	if nonce.bottom == 0 {
 		nonce.top += 1
 	}
 }
 
-func (nonce *gcmNonce) pred() {
+func (nonce gcmNonce) pred() {
 	nonce.bottom -= 1
+	// If bottom underflows, decrement top by 1
 	if nonce.bottom == math.MaxUint64 {
 		nonce.top -= 1
 	}
 }
 
 // A GCMSession stores the state of a GCM authenticated/encrypted session. This
-
 // includes the read/write nonces, memory buffers, and the GCM cipher itself.
 type GCMSession struct {
 	gcm        cipher.AEAD
-	readNonce  *gcmNonce
-	writeNonce *gcmNonce
+	readNonce  gcmNonce
+	writeNonce gcmNonce
 }
 
 // NewGCMSession accepts a symmetric secret key and returns a new GCMSession
@@ -64,8 +66,8 @@ func NewGCMSession(key [32]byte, self, remote id.Signatory) (*GCMSession, error)
 
 	gcmSession := &GCMSession{
 		gcm:        gcm,
-		readNonce:  &gcmNonce{},
-		writeNonce: &gcmNonce{},
+		readNonce:  gcmNonce{},
+		writeNonce: gcmNonce{},
 	}
 
 	if bytes.Compare(self[:], remote[:]) < 0 {
@@ -76,24 +78,18 @@ func NewGCMSession(key [32]byte, self, remote id.Signatory) (*GCMSession, error)
 		gcmSession.readNonce.top = math.MaxUint32
 		gcmSession.readNonce.bottom = math.MaxUint64
 		gcmSession.readNonce.countDown = true
-
 	}
 	return gcmSession, nil
 }
 
+// GCMEncoder accepts a GCMSession and an encoder that wraps data encryption
 func GCMEncoder(session *GCMSession, enc Encoder) Encoder {
 	return func(w io.Writer, buf []byte) (int, error) {
-		nonceBufTop, err := surge.ToBinary(session.writeNonce.top)
-		if err != nil {
-			return 0, fmt.Errorf("marshaling nonce to bytes: %v", err)
-		}
-		nonceBufBottom, err := surge.ToBinary(session.writeNonce.bottom)
-		if err != nil {
-			return 0, fmt.Errorf("marshaling nonce to bytes: %v", err)
-		}
-		nonceBuf := append(nonceBufTop, nonceBufBottom...)
-		session.writeNonce.change()
-		encoded := session.gcm.Seal(nil, nonceBuf, buf, nil)
+		nonceBuf := [12]byte{}
+		binary.BigEndian.PutUint32(nonceBuf[:4], session.writeNonce.top)
+		binary.BigEndian.PutUint64(nonceBuf[4:], session.writeNonce.bottom)
+		session.writeNonce.next()
+		encoded := session.gcm.Seal(nil, nonceBuf[:], buf, nil)
 		n, err := enc(w, encoded)
 		if err != nil {
 			return n, fmt.Errorf("Encoded sealed data: %v", err)
@@ -102,23 +98,18 @@ func GCMEncoder(session *GCMSession, enc Encoder) Encoder {
 	}
 }
 
+// GCMDEcoder accepts a GCMSession and a decoder that wraps data decryption
 func GCMDecoder(session *GCMSession, dec Decoder) Decoder {
 	return func(r io.Reader, buf []byte) (int, error) {
 		n, err := dec(r, buf)
 		if err != nil {
 			return n, fmt.Errorf("decoding data: %v", err)
 		}
-		nonceBufTop, err := surge.ToBinary(session.readNonce.top)
-		if err != nil {
-			return 0, fmt.Errorf("marshaling nonce to bytes: %v", err)
-		}
-		nonceBufBottom, err := surge.ToBinary(session.readNonce.bottom)
-		if err != nil {
-			return 0, fmt.Errorf("marshaling nonce to bytes: %v", err)
-		}
-		nonceBuf := append(nonceBufTop, nonceBufBottom...)
-		session.readNonce.change()
-		decrypted, err := session.gcm.Open(nil, nonceBuf, buf[:n], nil)
+		nonceBuf := [12]byte{}
+		binary.BigEndian.PutUint32(nonceBuf[:4], session.readNonce.top)
+		binary.BigEndian.PutUint64(nonceBuf[4:], session.readNonce.bottom)
+		session.readNonce.next()
+		decrypted, err := session.gcm.Open(nil, nonceBuf[:], buf[:n], nil)
 
 		if err != nil {
 			return 0, fmt.Errorf("opening sealed data: %v", err)

--- a/codec/gcm.go
+++ b/codec/gcm.go
@@ -94,7 +94,7 @@ func GCMEncoder(session *GCMSession, enc Encoder) Encoder {
 		if err != nil {
 			return n, fmt.Errorf("Encoded sealed data: %v", err)
 		}
-		return n, nil
+		return len(buf), nil
 	}
 }
 
@@ -116,6 +116,6 @@ func GCMDecoder(session *GCMSession, dec Decoder) Decoder {
 		}
 		copy(buf, decrypted)
 
-		return n, nil
+		return len(decrypted), nil
 	}
 }

--- a/handshake/ecies.go
+++ b/handshake/ecies.go
@@ -35,7 +35,7 @@ func ECIES(privKey *id.PrivKey, r *rand.Rand) Handshake {
 		defer close(remoteSecretKeyCh)
 
 		// A pointer to the pubKey contained in the privKey struct
-		localPubKeyPtr := privKey.PubKey()
+		localPubKey := privKey.PubKey()
 
 		// Generate a local secret key. We do it here, because it is needed by
 		// the writing and reading goroutine.

--- a/handshake/ecies.go
+++ b/handshake/ecies.go
@@ -51,8 +51,8 @@ func ECIES(privKey *id.PrivKey, r *rand.Rand) Handshake {
 
 			// Write local pubkey so that the remote peer knows how to encrypt
 			// its secret key and send it back to the local peer.
-			xBuf := paddedTo32(localPubKeyPtr.X)
-			yBuf := paddedTo32(localPubKeyPtr.Y)
+			xBuf := paddedTo32(localPubKey.X)
+			yBuf := paddedTo32(localPubKey.Y)
 			if _, err := conn.Write(xBuf[:]); err != nil {
 				errCh <- fmt.Errorf("write local pubkey x: %v", err)
 				return
@@ -149,7 +149,7 @@ func ECIES(privKey *id.PrivKey, r *rand.Rand) Handshake {
 			sessionKey[i] = localSecretKey[i] ^ remoteSecretKey[i]
 		}
 
-		self := id.NewSignatory(localPubKeyPtr)
+		self := id.NewSignatory(localPubKey)
 		remote := id.NewSignatory(&remotePubKey)
 		gcmSession, err := codec.NewGCMSession(sessionKey, self, remote)
 		if err != nil {


### PR DESCRIPTION
Removes the requirement of communicating nonce with the message, saving bandwidth and time. Follow up to PR #50 

gcm encoder and decoder nonces are decided based on comparison between the signatory hashes of each peer. The peer with the smaller hash counts down its encoder nonce (from max value) and count up its decoder nonce (from 0). The  peer with the larger hash does vice-versa