### PR TITLE
Random sampling of IDs in hash table

### DIFF
--- a/dht/table.go
+++ b/dht/table.go
@@ -188,7 +188,7 @@ func (table *InMemTable) RandomPeers(n int) []id.Signatory {
 
 	// Otherwise, use Floyd's sampling algorithm to select n random elements
 	set := make(map[int]struct{}, n)
-	randomSelection := make([]id.Signatory, n, 0)
+	randomSelection := make([]id.Signatory, 0, n)
 	for i := m - n; i < m; i++ {
 		index := table.randObj.Intn(i)
 		if _, ok := set[index]; !ok {

--- a/dht/table.go
+++ b/dht/table.go
@@ -31,10 +31,12 @@ type Table interface {
 	// Peers returns the n closest peers to the local peer, using XORing as the
 	// measure of distance between two peers.
 	Peers(int) []id.Signatory
+	// RandomPeers returns n random peer IDs, using either partial permutation
+	// or Floyd's sampling algorithm.
+	RandomPeers(int) []id.Signatory
 	// NumPeers returns the total number of peers with associated network
 	// addresses in the table.
 	NumPeers() int
-	RandomPeers(int) []id.Signatory
 
 	// AddSubnet to the table. This returns a subnet hash that can be used to
 	// read/delete the subnet. It is the merkle root hash of the peers in the

--- a/dht/table_test.go
+++ b/dht/table_test.go
@@ -157,12 +157,31 @@ var _ = Describe("DHT", func() {
 
 				Expect(quick.Check(f, &quick.Config{MaxCount: 10})).To(Succeed())
 			})
-		})
 
-		Context("when querying n random peers where n is larger than the number of peers present in table", func() {
-			It("should return the number of peers in table", func() {
+			Context("where the requested number is larger than the number of peers present in table", func() {
+				It("should return the number of peers in table", func() {
+					table, _ := initDHT()
+					numAddrs := rand.Intn(100)
+
+					// Insert `numAddrs` random addresses into the store.
+					for i := 0; i < numAddrs; i++ {
+						privKey := id.NewPrivKey()
+						sig := privKey.Signatory()
+						addr := wire.NewUnsignedAddress(wire.TCP, "172.16.254.1:3000", uint64(time.Now().UnixNano()))
+
+						table.AddPeer(sig, addr)
+					}
+
+					randomAddr := table.RandomPeers(numAddrs + rand.Intn(100))
+					Expect(len(randomAddr)).To(Equal(numAddrs))
+
+				})
+			})
+
+			It("should return a unique subset each time", func() {
 				table, _ := initDHT()
 				numAddrs := rand.Intn(100)
+				numRandAddrs := rand.Intn(numAddrs)
 
 				// Insert `numAddrs` random addresses into the store.
 				for i := 0; i < numAddrs; i++ {
@@ -173,9 +192,16 @@ var _ = Describe("DHT", func() {
 					table.AddPeer(sig, addr)
 				}
 
-				randomAddr := table.RandomPeers(numAddrs + rand.Intn(100))
-				Expect(len(randomAddr)).To(Equal(numAddrs))
+				lists := make([][]id.Signatory, 10)
+				for i := range lists {
+					lists[i] = table.RandomPeers(numRandAddrs)
+				}
 
+				for i := 0; i < 10; i++ {
+					for j := i+1; j < 10; j++ {
+						Expect(lists[i]).To(Not(Equal(lists[j])))
+					}
+				}
 			})
 		})
 

--- a/dht/table_test.go
+++ b/dht/table_test.go
@@ -133,6 +133,32 @@ var _ = Describe("DHT", func() {
 			})
 		})
 
+		Context("when querying random peers", func() {
+			It("should return the correct amount", func() {
+				table, _ := initDHT()
+
+				f := func(seed int64) bool {
+					numAddrs := rand.Intn(11000)
+
+					// Insert `numAddrs` random addresses into the store.
+					for i := 0; i < numAddrs; i++ {
+						privKey := id.NewPrivKey()
+						sig := privKey.Signatory()
+						addr := wire.NewUnsignedAddress(wire.TCP, "172.16.254.1:3000", uint64(time.Now().UnixNano()))
+
+						table.AddPeer(sig, addr)
+					}
+
+					numRandomAddrs := rand.Intn(numAddrs)
+					randomAddr := table.RandomPeers(numRandomAddrs)
+					Expect(len(randomAddr)).To(Equal(numRandomAddrs))
+					return true
+				}
+
+				Expect(quick.Check(f, &quick.Config{MaxCount: 10})).To(Succeed())
+			})
+		})
+
 		Context("when querying the number of addresses", func() {
 			It("should return the correct amount", func() {
 				table, _ := initDHT()

--- a/dht/table_test.go
+++ b/dht/table_test.go
@@ -159,6 +159,26 @@ var _ = Describe("DHT", func() {
 			})
 		})
 
+		Context("when querying n random peers where n is larger than the number of peers present in table", func() {
+			It("should return the number of peers in table", func() {
+				table, _ := initDHT()
+				numAddrs := rand.Intn(100)
+
+				// Insert `numAddrs` random addresses into the store.
+				for i := 0; i < numAddrs; i++ {
+					privKey := id.NewPrivKey()
+					sig := privKey.Signatory()
+					addr := wire.NewUnsignedAddress(wire.TCP, "172.16.254.1:3000", uint64(time.Now().UnixNano()))
+
+					table.AddPeer(sig, addr)
+				}
+
+				randomAddr := table.RandomPeers(numAddrs + rand.Intn(100))
+				Expect(len(randomAddr)).To(Equal(numAddrs))
+
+			})
+		})
+
 		Context("when querying the number of addresses", func() {
 			It("should return the correct amount", func() {
 				table, _ := initDHT()


### PR DESCRIPTION
Add ability to query n random elements from sorted array of IDs

Depending on size of sorted IDs and the number of random elements requested, the function either uses a partial permutation algorithm for sampling or uses Floyd's sampling algorithm

- [x] Full testing