### PR TITLE
Syncer Fixes

### DIFF
--- a/dht/table.go
+++ b/dht/table.go
@@ -31,10 +31,12 @@ type Table interface {
 	// Peers returns the n closest peers to the local peer, using XORing as the
 	// measure of distance between two peers.
 	Peers(int) []id.Signatory
+	// RandomPeers returns n random peer IDs, using either partial permutation
+	// or Floyd's sampling algorithm.
+	RandomPeers(int) []id.Signatory
 	// NumPeers returns the total number of peers with associated network
 	// addresses in the table.
 	NumPeers() int
-	RandomPeers(int) []id.Signatory
 
 	// AddSubnet to the table. This returns a subnet hash that can be used to
 	// read/delete the subnet. It is the merkle root hash of the peers in the

--- a/peer/opt.go
+++ b/peer/opt.go
@@ -8,9 +8,9 @@ import (
 )
 
 type SyncerOptions struct {
-	Logger  *zap.Logger
-	Alpha   int
-	Timeout time.Duration
+	Logger        *zap.Logger
+	Alpha         int
+	WiggleTimeout time.Duration
 }
 
 func DefaultSyncerOptions() SyncerOptions {
@@ -19,9 +19,9 @@ func DefaultSyncerOptions() SyncerOptions {
 		panic(err)
 	}
 	return SyncerOptions{
-		Logger:  logger,
-		Alpha:   DefaultAlpha,
-		Timeout: DefaultTimeout,
+		Logger:        logger,
+		Alpha:         DefaultAlpha,
+		WiggleTimeout: DefaultTimeout,
 	}
 }
 
@@ -35,8 +35,8 @@ func (opts SyncerOptions) WithAlpha(alpha int) SyncerOptions {
 	return opts
 }
 
-func (opts SyncerOptions) WithTimeout(timeout time.Duration) SyncerOptions {
-	opts.Timeout = timeout
+func (opts SyncerOptions) WithWiggleTimeout(timeout time.Duration) SyncerOptions {
+	opts.WiggleTimeout = timeout
 	return opts
 }
 

--- a/peer/sync.go
+++ b/peer/sync.go
@@ -88,8 +88,10 @@ func (syncer *Syncer) Sync(ctx context.Context, contentID []byte, hint *id.Signa
 	// blocking content again.
 	syncer.filter.Allow(contentID)
 	defer func() {
-		time.Sleep(syncer.opts.WiggleTimeout)
-		syncer.filter.Deny(contentID)
+		go func() {
+			time.Sleep(syncer.opts.WiggleTimeout)
+			syncer.filter.Deny(contentID)
+		}()
 	}()
 
 	// Ensure that pending content is removed.

--- a/peer/sync_test.go
+++ b/peer/sync_test.go
@@ -21,7 +21,7 @@ var _ = Describe("Peer", func() {
 			opts, peers, tables, contentResolvers, _, transports := setup(n)
 
 			for i := range opts {
-				opts[i].SyncerOptions = opts[i].SyncerOptions.WithTimeout(2 * time.Second)
+				opts[i].SyncerOptions = opts[i].SyncerOptions.WithWiggleTimeout(2 * time.Second)
 				peers[i] = peer.New(
 					opts[i],
 					transports[i])


### PR DESCRIPTION
This PR
- [x] updates the syncer to send sync requests in parallel
- [x] implements a workaround so that additional (correct) sync messages received don't cause the channel to be dropped because the messages get filtered

Testing
- [x] Basic test passing
- [x] Full testing