### PR TITLE
Fix/channel tests

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -449,11 +449,6 @@ func (ch *Channel) drainReader(ctx context.Context, r reader, m wire.Msg, mOk bo
 			}
 		}
 	}
-	if ch.opts.DrainInBackground {
-		ch.opts.Logger.Debug("drain: background", zap.String("addr", r.Conn.RemoteAddr().String()))
-		go f()
-		return
-	}
-	ch.opts.Logger.Debug("drain: foreground", zap.String("addr", r.Conn.RemoteAddr().String()))
-	f()
+	ch.opts.Logger.Debug("drain: background", zap.String("addr", r.Conn.RemoteAddr().String()))
+	go f()
 }

--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -169,7 +169,7 @@ var _ = Describe("Channels", func() {
 
 	Context("when a connection is replaced while sending messages", func() {
 		Context("when draining connections in the background", func() {
-			It("should send and receive all messages out of order", func() {
+			FIt("should send and receive all messages out of order", func() {
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
 
@@ -181,7 +181,7 @@ var _ = Describe("Channels", func() {
 				// Number of messages that we will test. This number is higher than
 				// in other tests, because we need sending/receiving to take long
 				// enough that replacements will happen.
-				n := uint64(10000)
+				n := uint64(3000)
 				// Send and receive messages in both direction; from local to
 				// remote, and from remote to local.
 				q1 := sink(localOutbound, n)

--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -20,8 +20,7 @@ var _ = Describe("Channels", func() {
 	run := func(ctx context.Context, remote id.Signatory) (*channel.Channel, <-chan wire.Msg, chan<- wire.Msg) {
 		inbound, outbound := make(chan wire.Msg), make(chan wire.Msg)
 		ch := channel.New(
-			channel.DefaultOptions().
-				WithDrainTimeout(3000*time.Millisecond),
+			channel.DefaultOptions().WithDrainTimeout(1500*time.Millisecond),
 			remote,
 			inbound,
 			outbound)
@@ -64,7 +63,6 @@ var _ = Describe("Channels", func() {
 			max := uint64(0)
 			received := make(map[uint64]int, n)
 			for iter := uint64(0); iter < n; iter++ {
-				time.Sleep(time.Millisecond)
 				select {
 				case msg := <-inbound:
 					data := binary.BigEndian.Uint64(msg.Data)
@@ -75,7 +73,7 @@ var _ = Describe("Channels", func() {
 					if inOrder {
 						Expect(data).To(Equal(iter))
 					}
-					if rand.Int()%1000 == 0 {
+					if rand.Int()%100 == 0 {
 						log.Printf("stream %v/%v", len(received), max+1)
 					}
 				case <-timeout:
@@ -169,7 +167,7 @@ var _ = Describe("Channels", func() {
 
 	Context("when a connection is replaced while sending messages", func() {
 		Context("when draining connections in the background", func() {
-			FIt("should send and receive all messages out of order", func() {
+			It("should send and receive all messages out of order", func() {
 				ctx, cancel := context.WithCancel(context.Background())
 				defer cancel()
 
@@ -181,7 +179,7 @@ var _ = Describe("Channels", func() {
 				// Number of messages that we will test. This number is higher than
 				// in other tests, because we need sending/receiving to take long
 				// enough that replacements will happen.
-				n := uint64(3000)
+				n := uint64(10000)
 				// Send and receive messages in both direction; from local to
 				// remote, and from remote to local.
 				q1 := sink(localOutbound, n)

--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Channels", func() {
 					if inOrder {
 						Expect(data).To(Equal(iter))
 					}
-					if rand.Int()%100 == 0 {
+					if rand.Int()%1000 == 0 {
 						log.Printf("stream %v/%v", len(received), max+1)
 					}
 				case <-timeout:

--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -181,7 +181,7 @@ var _ = Describe("Channels", func() {
 				// Number of messages that we will test. This number is higher than
 				// in other tests, because we need sending/receiving to take long
 				// enough that replacements will happen.
-				n := uint64(3000)
+				n := uint64(10000)
 				// Send and receive messages in both direction; from local to
 				// remote, and from remote to local.
 				q1 := sink(localOutbound, n)

--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -17,11 +17,10 @@ import (
 
 var _ = Describe("Channels", func() {
 
-	run := func(ctx context.Context, remote id.Signatory, drainInBg bool) (*channel.Channel, <-chan wire.Msg, chan<- wire.Msg) {
+	run := func(ctx context.Context, remote id.Signatory) (*channel.Channel, <-chan wire.Msg, chan<- wire.Msg) {
 		inbound, outbound := make(chan wire.Msg), make(chan wire.Msg)
 		ch := channel.New(
 			channel.DefaultOptions().
-				WithDrainInBackground(drainInBg).
 				WithDrainTimeout(3000*time.Millisecond),
 			remote,
 			inbound,
@@ -101,8 +100,8 @@ var _ = Describe("Channels", func() {
 
 			localPrivKey := id.NewPrivKey()
 			remotePrivKey := id.NewPrivKey()
-			localCh, localInbound, localOutbound := run(ctx, remotePrivKey.Signatory(), true)
-			remoteCh, remoteInbound, remoteOutbound := run(ctx, localPrivKey.Signatory(), true)
+			localCh, localInbound, localOutbound := run(ctx, remotePrivKey.Signatory())
+			remoteCh, remoteInbound, remoteOutbound := run(ctx, localPrivKey.Signatory())
 
 			// Remote channel will listen for incoming connections.
 			listen(ctx, remoteCh, remotePrivKey.Signatory(), localPrivKey.Signatory(), 3333)
@@ -138,8 +137,8 @@ var _ = Describe("Channels", func() {
 
 			localPrivKey := id.NewPrivKey()
 			remotePrivKey := id.NewPrivKey()
-			localCh, localInbound, localOutbound := run(ctx, remotePrivKey.Signatory(), true)
-			remoteCh, remoteInbound, remoteOutbound := run(ctx, localPrivKey.Signatory(), true)
+			localCh, localInbound, localOutbound := run(ctx, remotePrivKey.Signatory())
+			remoteCh, remoteInbound, remoteOutbound := run(ctx, localPrivKey.Signatory())
 
 			// Number of messages that we will test.
 			n := uint64(1000)
@@ -176,8 +175,8 @@ var _ = Describe("Channels", func() {
 
 				localPrivKey := id.NewPrivKey()
 				remotePrivKey := id.NewPrivKey()
-				localCh, localInbound, localOutbound := run(ctx, remotePrivKey.Signatory(), true)
-				remoteCh, remoteInbound, remoteOutbound := run(ctx, localPrivKey.Signatory(), true)
+				localCh, localInbound, localOutbound := run(ctx, remotePrivKey.Signatory())
+				remoteCh, remoteInbound, remoteOutbound := run(ctx, localPrivKey.Signatory())
 
 				// Number of messages that we will test. This number is higher than
 				// in other tests, because we need sending/receiving to take long
@@ -195,41 +194,6 @@ var _ = Describe("Channels", func() {
 				// Local channel will dial the listener (and re-dial once per
 				// second).
 				dial(ctx, localCh, localPrivKey.Signatory(), remotePrivKey.Signatory(), 3353, time.Second)
-
-				// Wait for sinking and streaming to finish.
-				<-q1
-				<-q2
-				<-q3
-				<-q4
-			})
-		})
-
-		Context("when draining connections in the foreground", func() {
-			It("should send and receive all messages in order", func() {
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-
-				localPrivKey := id.NewPrivKey()
-				remotePrivKey := id.NewPrivKey()
-				localCh, localInbound, localOutbound := run(ctx, remotePrivKey.Signatory(), false)
-				remoteCh, remoteInbound, remoteOutbound := run(ctx, localPrivKey.Signatory(), false)
-
-				// Number of messages that we will test. This number is higher than
-				// in other tests, because we need sending/receiving to take long
-				// enough that replacements will happen.
-				n := uint64(3000)
-				// Send and receive messages in both direction; from local to
-				// remote, and from remote to local.
-				q1 := sink(localOutbound, n)
-				q2 := stream(remoteInbound, n, true)
-				q3 := sink(remoteOutbound, n)
-				q4 := stream(localInbound, n, true)
-
-				// Remote channel will listen for incoming connections.
-				listen(ctx, remoteCh, remotePrivKey.Signatory(), localPrivKey.Signatory(), 3363)
-				// Local channel will dial the listener (and re-dial once per
-				// second).
-				dial(ctx, localCh, localPrivKey.Signatory(), remotePrivKey.Signatory(), 3363, time.Second)
 
 				// Wait for sinking and streaming to finish.
 				<-q1

--- a/channel/client_test.go
+++ b/channel/client_test.go
@@ -40,19 +40,21 @@ var _ = Describe("Client", func() {
 			defer time.Sleep(time.Millisecond) // Wait for the receiver to be shutdown.
 			ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 			defer cancel()
+			receiver := make(chan wire.Msg)
 			client.Receive(ctx, func(signatory id.Signatory, msg wire.Msg) error {
+				receiver <- msg
 				return nil
 			})
-			//for iter := uint64(0); iter < n; iter++ {
-			//	time.Sleep(time.Millisecond)
-			//	select {
-			//	case <-ctx.Done():
-			//		Expect(ctx.Err()).ToNot(HaveOccurred())
-			//	case msg := <-receiver:
-			//		data := binary.BigEndian.Uint64(msg.Data)
-			//		Expect(data).To(Equal(iter))
-			//	}
-			//}
+			for iter := uint64(0); iter < n; iter++ {
+				time.Sleep(time.Millisecond)
+				select {
+				case <-ctx.Done():
+					Expect(ctx.Err()).ToNot(HaveOccurred())
+				case msg := <-receiver:
+					data := binary.BigEndian.Uint64(msg.Data)
+					Expect(data).To(Equal(iter))
+				}
+			}
 		}()
 		return quit
 	}

--- a/channel/opt.go
+++ b/channel/opt.go
@@ -9,7 +9,6 @@ import (
 
 var (
 	DefaultDrainTimeout       = 30 * time.Second
-	DefaultDrainInBackground  = true
 	DefaultMaxMessageSize     = 4 * 1024 * 1024         // 4MB
 	DefaultRateLimit          = rate.Limit(1024 * 1024) // 1MB per second
 	DefaultInboundBufferSize  = 0
@@ -20,7 +19,6 @@ var (
 type Options struct {
 	Logger             *zap.Logger
 	DrainTimeout       time.Duration
-	DrainInBackground  bool
 	MaxMessageSize     int
 	RateLimit          rate.Limit
 	InboundBufferSize  int
@@ -36,7 +34,6 @@ func DefaultOptions() Options {
 	return Options{
 		Logger:             logger,
 		DrainTimeout:       DefaultDrainTimeout,
-		DrainInBackground:  DefaultDrainInBackground,
 		MaxMessageSize:     DefaultMaxMessageSize,
 		RateLimit:          DefaultRateLimit,
 		InboundBufferSize:  DefaultInboundBufferSize,
@@ -57,14 +54,6 @@ func (opts Options) WithLogger(logger *zap.Logger) Options {
 // all future messages sent to the connection will be lost.
 func (opts Options) WithDrainTimeout(timeout time.Duration) Options {
 	opts.DrainTimeout = timeout
-	return opts
-}
-
-// WithDrainInBackground enables/disable background draining of replaced
-// connections. Setting this to true can improve performance, but it also break
-// the deliver order of messages.
-func (opts Options) WithDrainInBackground(enable bool) Options {
-	opts.DrainInBackground = enable
 	return opts
 }
 


### PR DESCRIPTION
This PR makes several fixes for the channels.

1. It removes the ability to do foreground draining on replaced connections. This was causing sporadic failures in tests, because TCP connections can get themselves into "half closed" states. We also do not actually use this feature.
2. Draining readers did not respect sync messages. Now it does.
3. Readers could get blocked on decoding from the underlying connection if the connection was replaced at that same moment. This is now handled correctly, and blocking no longer occurs.