### PR TITLE
Channel race condition

### DIFF
--- a/channel/client.go
+++ b/channel/client.go
@@ -92,7 +92,7 @@ func (client *Client) Bind(remote id.Signatory) {
 			select {
 			case <-ctx.Done():
 				return
-			case msg := <-inbound
+			case msg := <-inbound:
 				select {
 				case <-ctx.Done():
 					return

--- a/channel/client.go
+++ b/channel/client.go
@@ -83,16 +83,21 @@ func (client *Client) Bind(remote id.Signatory) {
 	ctx, cancel := context.WithCancel(context.Background())
 	ch := New(client.opts, remote, inbound, outbound)
 	go func() {
-		defer close(inbound)
 		if err := ch.Run(ctx); err != nil {
 			client.opts.Logger.Error("run", zap.Error(err))
 		}
 	}()
 	go func() {
-		for msg := range inbound {
+		for {
 			select {
 			case <-ctx.Done():
-			case client.inbound <- Msg{Msg: msg, From: remote}:
+				return
+			case msg := <-inbound
+				select {
+				case <-ctx.Done():
+					return
+				case client.inbound <- Msg{Msg: msg, From: remote}:
+				}
 			}
 		}
 	}()


### PR DESCRIPTION
This PR fixes a race condition in the channel implementation. The problem was that when a channel is unbound from a client, the client will close the `inbound` channel, however the draining go routine may attempt to write to this channel.