### PR TITLE
Delete expired pending sync requests

### DIFF
--- a/aw.go
+++ b/aw.go
@@ -826,7 +826,7 @@ func (peer *Peer) handleEvent(e event) {
 
 				peer.filter.allow(contentID)
 
-				if uint(len(peer.pendingSyncs)) >= peer.Opts.MaxPendingSyncs {
+				if numPendingSyncs(peer.pendingSyncs) >= peer.Opts.MaxPendingSyncs {
 					e.errorResponder <- ErrTooManyPendingSyncs
 				} else {
 					pending := pendingSync{
@@ -1696,4 +1696,13 @@ func write(
 			}
 		}
 	}
+}
+
+func numPendingSyncs(pendingSyncs map[string]pendingSync) uint {
+	for id, pSync := range pendingSyncs {
+		if pSync.ctx.Err() != nil {
+			delete(pendingSyncs, id)
+		}
+	}
+	return uint(len(pendingSyncs))
 }

--- a/aw_test.go
+++ b/aw_test.go
@@ -372,18 +372,13 @@ var _ = Describe("Peer", func() {
 			peer2.ContentResolver.InsertContent(successID, []byte("content"))
 
 			for i := 0; i < int(opts.MaxPendingSyncs); i++ {
-				i := i
-				go func() {
-					contentID := []byte(fmt.Sprintf("%v", i))
-					syncCtx, syncCancel := context.WithTimeout(ctx, 100*time.Millisecond)
-					peer1.Sync(syncCtx, contentID, nil)
-					syncCancel()
-				}()
+				contentID := []byte(fmt.Sprintf("%v", i))
+				syncCtx, syncCancel := context.WithTimeout(ctx, 1*time.Millisecond)
+				peer1.Sync(syncCtx, contentID, nil)
+				syncCancel()
 			}
 
-			time.Sleep(100 * time.Millisecond)
-
-			syncCtx, syncCancel := context.WithTimeout(ctx, 100*time.Millisecond)
+			syncCtx, syncCancel := context.WithTimeout(ctx, 10*time.Millisecond)
 			_, err := peer1.Sync(syncCtx, successID, nil)
 			syncCancel()
 


### PR DESCRIPTION
This PR fixes an issue where pending syncs that have expired contexts will remain in the `pendingSyncs` map, which means that this map can fill up and erroneously prevent future syncs.